### PR TITLE
buildProperties.workDir - null pointer execption

### DIFF
--- a/Build/MortgageApplication/build/deploy.groovy
+++ b/Build/MortgageApplication/build/deploy.groovy
@@ -171,6 +171,7 @@ def parseInput(String[] cliArgs){
 		buildPropFile.withInputStream {
     			buildProperties.load(it)
 		}
+		if (buildProperties.workDir != null)    
 		properties.workDir = buildProperties.workDir
 	}
 


### PR DESCRIPTION
When the workDir is not mentioned in build.properties and supplied via command line, the original version failed because of null pointer exception. So I added a null check before moving the value.