### PR TITLE
Changing property name at the manifest level

### DIFF
--- a/Build/MortgageApplication/build/deploy.groovy
+++ b/Build/MortgageApplication/build/deploy.groovy
@@ -69,7 +69,7 @@ def xml = new MarkupBuilder(writer)
 xml.manifest(type:"MANIFEST_SHIPLIST"){
 	//top level property will be added as version properties
         //requires UCD v6.2.6 and above
-	property(name : buildResult.getGroup() + "-" + buildResult.getLabel(), value : buildResult.getUrl())
+	property(name : buildResult.getGroup() + "-buildResultUrl", value : buildResult.getUrl())
 	//iterate through the outputs and add container and resource elements
 	executes.each{ execute -> 
  		execute.getOutputs().each{ output -> 


### PR DESCRIPTION
Current code generates a new property for every version

property name='MortageApplication-master-build.20200819.021543.015' value='https://example.com:9443/dbb/rest/buildResult/1000' 

But this is wrong. In UCD, the property name needs to be same across versions. Only the property value should change. Otherwise, UCD creates unnecessary duplicate properties and versions end up with too many properties. 

New code should generate 
property name='MortageApplication-master-build-buildResultUrl' value='https://example.com:9443/dbb/rest/buildResult/1000' 

Here the property name will be always constant.