### PR TITLE
Add support for Copy_TO_PDS build report records to deploy.groovy

### DIFF
--- a/Build/MortgageApplication/build/deploy.groovy
+++ b/Build/MortgageApplication/build/deploy.groovy
@@ -44,8 +44,8 @@ def dependencies = buildReport.getRecords().findAll{it.getType()==DefaultRecordF
 println("** Find deployable outputs in the build report ")
 // the following example finds all the build output with deployType set
 def executes= buildReport.getRecords().findAll{
-	it.getType()==DefaultRecordFactory.TYPE_EXECUTE && 
-	!it.getOutputs().findAll{ o -> 
+    (it.getType()==DefaultRecordFactory.TYPE_EXECUTE || it.getType()==DefaultRecordFactory.TYPE_COPY_TO_PDS)  && 
+        !it.getOutputs().findAll{ o -> 
 		o.deployType != null
 	}.isEmpty()
 } 
@@ -78,7 +78,8 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 				resource(name:member, type:"PDSMember", deployType:output.deployType){
 					// add any custom properties needed 
 					property(name:"buildcommand", value:execute.getCommand())
-					property(name:"buildoptions", value:execute.getOptions())
+					if (execute.getType()==DefaultRecordFactory.TYPE_EXECUTE)
+					   property(name:"buildoptions", value:execute.getOptions())
 					// add source information
 					inputs(url : ""){
 						input(name : execute.getFile(), compileType : "Main")


### PR DESCRIPTION
Even though MortgageApplication will be replaced with a smaller sample application in the next release of DBB and `deploy.groovy` has already been replaced by the [CreateUCDComponentVersion](https://github.com/IBM/dbb/tree/master/Pipeline/CreateUCDComponentVersion) sample, it should still update this sample since we missed updating it in DBB v1.0.8 release when we introduced the changes to CopyToPDS. 