### PR TITLE
Updated documentation of Jenkins scripts

### DIFF
--- a/Utilities/Jenkins/README.md
+++ b/Utilities/Jenkins/README.md
@@ -1,7 +1,10 @@
 # Jenkins Utility Scripts
 These sample utility scripts are supplied to address issues when running Jenkins remote agents on z/OS UNIX System Services (USS).
-
+## Rocket git environment
 `gitenv.sh` - A convinient shell script that sets all the environment variables required by Rocket's Git port for USS.  Add the shell script to the Jenkins remote agent configuration's prefix start command to automatically set the environment variables. **IMPORTANT!** *The shell script requires configuration.  See the comment on how to modify the script for your system.*
+
+## Git credentials to access central git provider
+The Jenkins Git client plugin is used to specify the gitcredentials used in the communication with the central git provider. When managing the credentials within Jenkins, temporary files are written to the build workspace. Please see the available scripts to address encoding issues depending on the version of the Jenkins Git client plugin.
 
 `git-jenkins.sh` - Resolves two encoding issues when using the Git client plugin that is part of the Jenkins Freestyle project. 
 1. The plugin issues a git rev-parse command in which some of the output from the command is encoded in UTF-8 instead of EBCDIC.  The shell script pipes all command output through ICONV. 
@@ -9,8 +12,13 @@ These sample utility scripts are supplied to address issues when running Jenkins
 
 Use the `git-jenkins.sh` script by overriding the Git tool location with this script in the Node Properties of the remote agent configuration.
 
-`git-jenkins2.sh` - Resolves encoding issues with the git client plugin v3.0 onwards.
-1. Enables to use credentials managed in Jenkins to handle HTTP(s) connections to the git provider
-2. Enables to use a SSH passphrase managed in Jenkins for connections to the git provider.
+`git-jenkins2.sh` resolves encoding issues with the *Jenkins Git client plugin v3.0 onwards*, while `git-jenkins3.sh` does that for *Jenkins Git client plugin < v3.0*, like 2.7.x or 2.8.x. 
 
-Use the git-jenkins2.sh script by overriding the Git tool location with this script in the Node Properties of the remote agent configuration.
+1. The plugin creates temporary shell scripts to handle the HTTP communication with the central Git server - but in different ways which cause the different scripts. These temporary files are encoded in UTF-8 and need to be converted to EBDCDIC. This script enables to use credentials managed in Jenkins to handle HTTP(s) connections to the central Git provider.
+2. In the case of managing SSH keys and SSH passphrases in Jenkins to handle the communication with the central Git server, the plugin creates temporary files like in the first case for http communication. The script enables to use a SSH passphrase managed in Jenkins for connections to the git provider.
+
+Use the `git-jenkins2.sh` or the `git-jenkins3.sh` script by overriding the Git tool location with this script in the Node Properties of the remote agent configuration.
+
+Starting with Git client plugin 3.4.1, the plugin introduced a set of new environment variables, to specify the file encoding of the temporary files, which make the above git-jenkins scripts obsolete.
+
+More about this topic, can be found in this IBM Technote: [zDevops: Managing git credentials in Jenkins to access the central git provider](https://www.ibm.com/support/techdocs/atsmastr.nsf/WebIndex/TD106439) 

--- a/Utilities/Jenkins/README.md
+++ b/Utilities/Jenkins/README.md
@@ -4,20 +4,22 @@ These sample utility scripts are supplied to address issues when running Jenkins
 `gitenv.sh` - A convinient shell script that sets all the environment variables required by Rocket's Git port for USS.  Add the shell script to the Jenkins remote agent configuration's prefix start command to automatically set the environment variables. **IMPORTANT!** *The shell script requires configuration.  See the comment on how to modify the script for your system.*
 
 ## Git credentials to access central git provider
-The Jenkins Git client plugin is used to specify the gitcredentials used in the communication with the central git provider. When managing the credentials within Jenkins, temporary files are written to the build workspace. Please see the available scripts to address encoding issues depending on the version of the Jenkins Git client plugin.
+The Jenkins Git client plugin is used to specify the gitcredentials used in the communication with the central git provider. When managing the credentials within Jenkins, temporary files are written to the build workspace.
 
-`git-jenkins.sh` - Resolves two encoding issues when using the Git client plugin that is part of the Jenkins Freestyle project. 
+Please see the available scripts to address encoding issues depending on the version of the Jenkins Git client plugin.
+
+`git-jenkins.sh` - Resolves two encoding issues when using the *Jenkins Git client plugin < v3.0* that is part of the Jenkins Freestyle project:
 1. The plugin issues a git rev-parse command in which some of the output from the command is encoded in UTF-8 instead of EBCDIC.  The shell script pipes all command output through ICONV. 
 2. The plugin creates a temporary shell scripts to handle SSH communication with Git.  However these shell scripts are encoded in UTF-8 and need to be converted to EBCDIC to be invoked.
 
-Use the `git-jenkins.sh` script by overriding the Git tool location with this script in the Node Properties of the remote agent configuration.
+`git-jenkins2.sh` resolves encoding issues with the *Jenkins Git client plugin v3.0 onwards* for connecting to the central git provider via HTTP or SSH keys, while
 
-`git-jenkins2.sh` resolves encoding issues with the *Jenkins Git client plugin v3.0 onwards*, while `git-jenkins3.sh` does that for *Jenkins Git client plugin < v3.0*, like 2.7.x or 2.8.x. 
+`git-jenkins3.sh` does the same for *Jenkins Git client plugin < v3.0*, like 2.7.x or 2.8.x. 
 
 1. The plugin creates temporary shell scripts to handle the HTTP communication with the central Git server - but in different ways which cause the different scripts. These temporary files are encoded in UTF-8 and need to be converted to EBDCDIC. This script enables to use credentials managed in Jenkins to handle HTTP(s) connections to the central Git provider.
 2. In the case of managing SSH keys and SSH passphrases in Jenkins to handle the communication with the central Git server, the plugin creates temporary files like in the first case for http communication. The script enables to use a SSH passphrase managed in Jenkins for connections to the git provider.
 
-Use the `git-jenkins2.sh` or the `git-jenkins3.sh` script by overriding the Git tool location with this script in the Node Properties of the remote agent configuration.
+Use the `git-jenkins.sh`,  `git-jenkins2.sh` or the `git-jenkins3.sh` script by overriding the Git tool location with this script under the Node Properties of the remote Jenkins agent configuration.
 
 Starting with Git client plugin 3.4.1, the plugin introduced a set of new environment variables, to specify the file encoding of the temporary files, which make the above git-jenkins scripts obsolete.
 

--- a/Utilities/Jenkins/git-jenkins3.sh
+++ b/Utilities/Jenkins/git-jenkins3.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Licensed materials - Property of IBM
+# 5655-AC5 Copyright IBM Corp. 2018, 2018
+# All rights reserved
+# US Government users restricted rights  -  Use, duplication or
+# disclosure restricted by GSA ADP schedule contract with IBM Corp.
+#
+# Support credential management in Jenkins for git client plugin < 3.0
+#
+###################################################################
+
+# Set current dir to direct temp outputs to @tmp dir
+
+currentdir=$(pwd)
+
+# git operating via HTTP/S
+# Setting encoding of temporary files for git askpass
+# Redirect of output is mandatory
+if test -n "$SSH_ASKPASS"; then
+  if test -f "$SSH_ASKPASS"; then
+     # check the current tag, if ibm-1047 don't iconv
+     chtag -p $SSH_ASKPASS | grep -q "IBM-1047" >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     if [ $? -eq 0 ]; then
+       echo 'file already in ibm-1047' >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     else
+     chtag -p $SSH_ASKPASS >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     chtag -t -c UTF-8 $SSH_ASKPASS >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     iconv -f utf-8 -T -t IBM-1047 $SSH_ASKPASS > $SSH_ASKPASS.tmp
+     mv $SSH_ASKPASS.tmp $SSH_ASKPASS >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     chmod 700 $SSH_ASKPASS >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     fi
+   fi
+fi
+
+# git operating via SSH
+if test -n "$GIT_SSH"; then
+  if test -f "$GIT_SSH"; then
+     chtag -p $GIT_SSH | grep -q "IBM-1047" >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     if [ $? -eq 0 ]; then
+       echo 'file already in ibm-1047' >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     else
+      chtag -p $GIT_SSH >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+      chtag -t -c UTF-8 $GIT_SSH >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+      iconv -f utf-8 -T -t IBM-1047 $GIT_SSH > $GIT_SSH.tmp
+      mv $GIT_SSH.tmp $GIT_SSH >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+      chmod 700 $GIT_SSH >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+
+      keyFile=$(cat $GIT_SSH | grep "ssh -i" | sed 's/^[^"]*"\([^"]*\)".*/\1/')
+      if test -n "$keyFile"; then
+       chtag -p $keyFile >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+       chtag -t -c UTF-8 $keyFile >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+       iconv -f utf-8 -T -t IBM-1047 $keyFile > $keyFile.tmp
+       mv $keyFile.tmp $keyFile >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+       chmod 600 $keyFile >>$currentdir@tmp/git-jenkins-wrapper.log 2>&1
+     fi
+    fi
+  fi
+fi
+
+#git "$@" | iconv -f ibm-1047 -t ibm-1047
+git "$@"


### PR DESCRIPTION
Jenkins Git client now supports to set the target codepages as environment variables. I have enhanced the documentation to explain the different scenarios.

Additionally, added git-jenkins3.sh to supports http communication for older versions of the plugin.