### PR TITLE
Change zos encoding for groovy to utf-8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,7 @@
 *.rex zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.rexx zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.txt zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
-*.groovy zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
+*.groovy zos-working-tree-encoding=utf-8 git-encoding=utf-8
 *.sh zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.properties zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.asm zos-working-tree-encoding=ibm-1047 git-encoding=utf-8


### PR DESCRIPTION
Groovy code typically should be encoded as utf-8 instead of EBCDIC especially since gitenv.sh sets JAVA_TOOL_OPTIONS='-Dfile.encoding=utf-8'