### PR TITLE
idz code review - add support for custom syslib

### DIFF
--- a/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
+++ b/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
@@ -71,8 +71,7 @@ def includes= buildReport.getRecords().findAll{
 }
 
 println("** Found source code processed in the build report.")
-sources.each {		
-	println(" ${it.getSource()} ,  ${it.getDestination()}")	}
+sources.each {		 println(" ${it.getSource()} ,  ${it.getDestination()}")	}
 println("** Found include files processed in the build report to extract SYSLIB.")
 
 if (sources.size == 0){
@@ -128,7 +127,7 @@ else
 		println "** Saving spool output to ${props.workDir}"
 		def logFile = new File("${props.workDir}/CodeReviewSpool-${codeRev.getSubmittedJobId()}.txt")
 		codeRev.saveOutput(logFile, props.logEncoding)
-		
+
 		codeRev.getAllDDNames().each({ ddName ->
 			if (ddName == 'XML') {
 				def ddfile = new File("${props.workDir}/CodeReview${ddName}.xml")
@@ -173,15 +172,15 @@ def createCodeReviewExec(String jobcard, String ruleFile, String customRuleFile,
 //*
 //AKGCREV EXEC PROC=AKGCR
 """
+	// add default dummy
 	jcl+="//SYSLIB   DD DUMMY \n"
 	// add identified syslib
-	syslib.eachWithIndex {it, index ->
-		if (index == 0 ) jcl+="//SYSLIB   DD DISP=SHR,DSN=${it} \n"
-		else jcl+="//         DD DISP=SHR,DSN=${it} \n"}
-	// add libraries from property file
+	syslib.each { jcl+="//         DD DISP=SHR,DSN=${it} \n"}
+	// add syslib libraries from property file
 	if (props.codereview_syslib){
 		props.codereview_syslib.split(',').each { jcl+="//         DD DISP=SHR,DSN=${it} \n" }
 	}
+	
 	if ( customRuleFile  ) {
 		def lines = formatJCLPath("//CUSTRULE  DD PATH='$customRuleFile'")
 		lines.each{ jcl += it + "\n" }

--- a/Pipeline/RunIDZCodeReview/codereview.properties
+++ b/Pipeline/RunIDZCodeReview/codereview.properties
@@ -27,3 +27,8 @@ codereview_includedIncludeFiles=**/*.cpy
 ## Specify the L=COBOL parameter for the Code Review List mapping
 codereview_languageMapping=COBOL :: **/*.cbl
 codereview_languageMapping=PLI :: **/*.pli
+
+#
+## Additional datasets added to the SYSLIB concatenation for the code review application
+## codereview_syslib=JENKINS.EXTERNAL.COPY
+codereview_syslib=

--- a/Pipeline/RunIDZCodeReview/codereview.properties
+++ b/Pipeline/RunIDZCodeReview/codereview.properties
@@ -29,6 +29,6 @@ codereview_languageMapping=COBOL :: **/*.cbl
 codereview_languageMapping=PLI :: **/*.pli
 
 #
-## Additional datasets added to the SYSLIB concatenation for the code review application
+## Specify a comma separated list of additional datasets added to the SYSLIB concatenation for the code review application
 ## codereview_syslib=JENKINS.EXTERNAL.COPY
 codereview_syslib=


### PR DESCRIPTION
Please see an enhancement to provide a custom SYSLIB concatenation through the properties file. See #71 

Couple of additional comments:
- I switched from standard JAVA Properties to DBB BuildProperties.
- I had to rename the `properties` variable to `props`. I have no idea, but when using `properties` then `properties.workDir` turned `null` within an each loop to extract the DD Outputs, even that @Field was defined ... I have not found that it is a reserved word or anything.