### PR TITLE
Package Build Outputs

### DIFF
--- a/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
@@ -1,0 +1,182 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HTTP;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+
+// Very basic script to upload/download from artifactory (replacement of curl)
+@Field int retryCount = 50
+@Field int conPoolSize = 10
+@Field int timeout = 300 // 5 Minutes in seconds
+@Field int timeoutMilliSeconds = timeout * 1000;
+
+class CustomRetryHandler extends DefaultHttpRequestRetryHandler {
+	boolean verbose = false
+	CustomRetryHandler(int connectionRetries, boolean verbose) {
+		super(connectionRetries, true);
+		this.verbose = verbose
+	}
+
+	@Override
+	public boolean retryRequest(IOException exception, int totalCount, HttpContext context) {
+		HttpClientContext clientContext = HttpClientContext.adapt(context);
+		if ( verbose) println("*? WARNING: Error occurred for request " + clientContext.getRequest().getRequestLine().toString() + ": " + exception.getMessage() + ".");
+		if (totalCount > retryCount) {
+			println("*? Error occurred for request " + clientContext.getRequest().getRequestLine().toString() + ": " + exception.getMessage() + ".");
+			return false;
+		}
+		Thread.sleep(1000);
+		boolean shouldRetry = super.retryRequest(exception, totalCount, context);
+		if (shouldRetry) {
+			if ( verbose) println("*? WARNING: Attempting retry #" + totalCount);
+			return true;
+		}
+		return false;
+	}
+}
+
+run(args)
+
+def upload(String url, String fileName, String user, String password, boolean verbose) throws IOException {
+
+	System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true")
+	
+	RequestConfig requestConfig = RequestConfig
+		.custom()
+		.setSocketTimeout(timeoutMilliSeconds)
+		.setConnectTimeout(timeoutMilliSeconds)
+		.setCircularRedirectsAllowed(true)
+		.setExpectContinueEnabled(true)
+		.build();
+	
+	HttpPut httpPut = new HttpPut(url);
+	httpPut.setConfig(requestConfig);
+	httpPut.addHeader(HTTP.EXPECT_DIRECTIVE, HTTP.EXPECT_CONTINUE);
+	httpPut.addHeader(HTTP.CONN_DIRECTIVE,HTTP.CONN_KEEP_ALIVE);
+	
+	if ( verbose ) println( "** Headers: " + httpPut.getAllHeaders());
+	if ( verbose ) println( "** Request: " + httpPut );
+	
+	FileEntity fileEntity = new FileEntity(new File(fileName));
+	fileEntity.setContentType("binary/octet-stream");
+	httpPut.setEntity(fileEntity);
+
+	HttpClientContext clientContext = HttpClientContext.create();
+
+	CredentialsProvider provider = new BasicCredentialsProvider();
+	UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(user, password);
+	provider.setCredentials(AuthScope.ANY, credentials);
+	clientContext.setCredentialsProvider(provider);
+
+	PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+	connectionManager.setMaxTotal(conPoolSize);
+	connectionManager.setDefaultMaxPerRoute(conPoolSize);
+
+	HttpClientBuilder builder = HttpClientBuilder.create().setConnectionManager(connectionManager).setDefaultRequestConfig(requestConfig).useSystemProperties()
+	builder.setRetryHandler(new CustomRetryHandler(retryCount, verbose));
+
+
+	CloseableHttpClient httpClient = builder.build()
+	
+	HttpResponse response = httpClient.execute(httpPut, clientContext);
+	
+	if ( verbose ) println( "** Response: " + response );
+		
+	int statusCode = response.getStatusLine().getStatusCode();
+
+	if ((statusCode != HttpStatus.SC_CREATED) && (statusCode != HttpStatus.SC_OK)) {
+		if (response.getEntity() != null) {
+			InputStream source = response.getEntity().getContent();
+			byte[] buffer = new byte[8192];
+			int read;
+			while ((read = source.read(buffer)) != -1) {
+				System.err.write(buffer, 0, read);
+			}
+		}
+		throw new RuntimeException("Artifactory upload failed: " + statusCode);
+	}
+	httpClient.close();
+}
+
+def download(String url, String fileName, String user, String password, boolean verbose) throws ClientProtocolException, IOException  {
+	RequestConfig requestConfig = RequestConfig
+		.custom()
+		.setSocketTimeout(timeoutMilliSeconds)
+		.setConnectTimeout(timeoutMilliSeconds)
+		.setCircularRedirectsAllowed(true)
+		.setExpectContinueEnabled(true)
+		.build();
+
+	HttpGet get = new HttpGet(url);
+	get.setConfig(requestConfig);
+
+	HttpClientContext clientContext = HttpClientContext.create();
+	CredentialsProvider provider = new BasicCredentialsProvider();
+	UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(user, password);
+	provider.setCredentials(AuthScope.ANY, credentials);
+	clientContext.setCredentialsProvider(provider);
+
+	CloseableHttpClient httpClient = HttpClients.custom().useSystemProperties().build()
+	
+	HttpResponse response = httpClient.execute(get, clientContext);
+	InputStream source = response.getEntity().getContent();
+	FileOutputStream out = new FileOutputStream(fileName);
+	byte[] buffer = new byte[8192];
+	int read;
+	while ((read = source.read(buffer)) != -1) {
+		out.write(buffer, 0, read);
+	}
+	out.close();
+	httpClient.close();
+}
+
+
+//Parsing the command line
+def run(String[] cliArgs)
+{
+	System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true")
+	def cli = new CliBuilder(usage: "Artifactory.groovy [options]", header: '', stopAtNonOption: false)
+	cli.h(longOpt:'help', 'Prints this message')
+	cli.u(longOpt:'url', args:1, required:true, 'Artifactory file uri location')
+	cli.fU(longOpt:'fileToUpload', args:1, 'The full path of the file to upload')
+	cli.fD(longOpt:'fileToDownload', args:1, 'The full path of the file to download')
+	cli.U(longOpt:'user', args:1, required:true, 'Artifactory user id')
+	cli.P(longOpt:'password', args:1, required:true, 'Artifactory password')
+	cli.v(longOpt:'verbose', 'Flag to turn on script trace')
+	def opts = cli.parse(cliArgs)
+
+	// if opt parse fail exit.
+	if (! opts) {
+		System.exit(1)
+	}
+
+	if (opts.h)
+	{
+		cli.usage()
+		System.exit(0)
+	}
+	
+	if ( opts.fU) {
+		upload(opts.u, opts.fU, opts.U, opts.P, opts.v)
+	} else {
+		download(opts.u, opts.fD, opts.U, opts.P, opts.v)
+	}
+}

--- a/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
@@ -153,7 +153,7 @@ def download(String url, String fileName, String user, String password, boolean 
 def run(String[] cliArgs)
 {
 	System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true")
-	def cli = new CliBuilder(usage: "Artifactory.groovy [options]", header: '', stopAtNonOption: false)
+	def cli = new CliBuilder(usage: "ArtifactoryHelpers.groovy [options]", header: '', stopAtNonOption: false)
 	cli.h(longOpt:'help', 'Prints this message')
 	cli.u(longOpt:'url', args:1, required:true, 'Artifactory file uri location')
 	cli.fU(longOpt:'fileToUpload', args:1, 'The full path of the file to upload')

--- a/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
@@ -57,8 +57,6 @@ run(args)
 
 def upload(String url, String fileName, String user, String password, boolean verbose) throws IOException {
 
-	System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true")
-	
 	RequestConfig requestConfig = RequestConfig
 		.custom()
 		.setSocketTimeout(timeoutMilliSeconds)
@@ -152,7 +150,7 @@ def download(String url, String fileName, String user, String password, boolean 
 //Parsing the command line
 def run(String[] cliArgs)
 {
-	System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true")
+
 	def cli = new CliBuilder(usage: "ArtifactoryHelpers.groovy [options]", header: '', stopAtNonOption: false)
 	cli.h(longOpt:'help', 'Prints this message')
 	cli.u(longOpt:'url', args:1, required:true, 'Artifactory file uri location')

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -190,7 +190,7 @@ def getDatasetName(String fullname){
  * run process
  */
 def runProcess(ArrayList cmd, File dir){
-	if (props.verbose) println "executing $cmd: "
+	if (props.verbose && props.verbose.toBoolean()) println "executing $cmd: "
 	StringBuffer response = new StringBuffer()
 	StringBuffer error = new StringBuffer()
 
@@ -205,7 +205,7 @@ def runProcess(ArrayList cmd, File dir){
 
 	}else{
 		println("*! Error executing $cmd \n" + error.toString())
-		//System.exit(rc)
+		//System.exit(1)
 	}
 	return rc
 }

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -249,9 +249,7 @@ def runProcess(ArrayList cmd, File dir){
 	println(response.toString())
 
 	def rc = p.exitValue();
-	if(rc==0){
-
-	}else{
+	if(rc!=0){
 		println("*! Error executing $cmd \n" + error.toString())
 		//System.exit(1)
 	}

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -1,0 +1,264 @@
+import java.io.File
+import java.io.UnsupportedEncodingException
+import java.security.MessageDigest
+import org.apache.http.entity.FileEntity
+import com.ibm.dbb.build.*
+import com.ibm.dbb.build.DBBConstants.CopyMode
+import com.ibm.dbb.build.report.BuildReport
+import com.ibm.dbb.build.report.records.DefaultRecordFactory
+import groovy.transform.*
+
+/************************************************************************************
+ * This script creates a simplified package with the outputs generated from a DBB build 
+ * Optionally, it publishes it to an Artifactory repository.
+ *
+ * usage: PackageBuildOutputs.groovy [options]
+ *
+ * options:
+ *  -w,--workDir <dir>            Absolute path to the DBB build output directory
+ *  -v,--versionName <name>       Name of the sub directory path
+ *  -h,--help                     Prints this message
+ *  -prop,--propertyFile          Absolute path to a property file containing application specific Artifactory configuration (Optional)
+ *  -p,--publish                  Leverage the Artifactory configuration to upload the package (Optional; requires -prop)
+ *
+ * Version 0 - 2019
+ *  called PublishLoadModule.groovy and located in Build/PublishLoadModules
+ *
+ * Version 1 - 2021
+ *  Re-Design to run as a post-build script and make publishing optional
+ *
+ ************************************************************************************/
+
+// start create & publish package
+@Field Properties props = parseInput(args)
+def startTime = new Date()
+props.startTime = startTime.format("yyyyMMdd.hhmmss.mmm")
+println("** PackageBuildOutputs start at $props.startTime")
+println("** Properties at startup:")
+props.each{k,v->
+	println "   $k -> $v"
+}
+
+def loadDatasets = properties.loadDatasets
+
+// read build report data
+println("** Read build report data from $props.workDir/BuildReport.json")
+def jsonOutputFile = new File("${props.workDir}/BuildReport.json")
+
+if(!jsonOutputFile.exists()){
+	println("** Build report data at $props.workDir/BuildReport.json not found")
+	System.exit(1)
+}
+
+def buildReport= BuildReport.parse(new FileInputStream(jsonOutputFile))
+
+// finds all the build outputs with a deployType
+def executes= buildReport.getRecords().findAll{
+	try {
+		(it.getType()==DefaultRecordFactory.TYPE_EXECUTE || it.getType()==DefaultRecordFactory.TYPE_COPY_TO_PDS) &&
+				!it.getOutputs().isEmpty()
+	} catch (Exception e){}
+}
+
+// Remove outputs without deployType + ZUNIT-TESTCASEs
+executes.each {
+	def unwantedOutputs =  it.getOutputs().findAll{ o ->
+		o.deployType == null || o.deployType == 'ZUNIT-TESTCASE'
+	}
+	it.getOutputs().removeAll(unwantedOutputs)
+}
+
+assert executes.size() > 0, "There are no outputs found in the build report"
+
+// Read buildInfo to obtain build information
+
+def buildInfo = buildReport.getRecords().findAll{
+	try {
+		it.getType()==DefaultRecordFactory.TYPE_BUILD_RESULT
+	} catch (Exception e){}
+}
+
+def String tarFileLabel = buildInfo[0].label
+def String tarFileName = "${buildInfo[0].label}.tar"
+def String buildGroup = buildInfo[0].group
+
+
+//Create a temporary directory on zFS to copy the load modules from data sets to
+def tempLoadDir = new File("$props.workDir/tempPackageDir")
+!tempLoadDir.exists() ?: tempLoadDir.deleteDir()
+tempLoadDir.mkdirs()
+
+//Iterate over executes and obtain map of <dataset,member>
+def loadDatasetToMembersMap = [:]
+def loadCount = 0
+executes.each { execute ->
+	execute.outputs.each { output ->
+		def (dataset, member) = output.dataset.split("\\(|\\)")
+		if (loadDatasetToMembersMap[dataset] == null)
+			loadDatasetToMembersMap[dataset] = []
+		loadDatasetToMembersMap[dataset].add(member)
+		loadCount++
+	}
+}
+
+//For each load modules, use CopyToHFS with option 'CopyMode.LOAD' to maintain SSI
+println("** Copying BuildOutputs to temporary package dir.")
+
+CopyToHFS copy = new CopyToHFS()
+
+def copyModeMap = ["COPYBOOK": CopyMode.TEXT, "COPY": CopyMode.TEXT, "DBRM": CopyMode.BINARY, "LOAD": CopyMode.LOAD]
+
+println "*** Number of build outputs to publish: $loadCount"
+loadDatasetToMembersMap.each { dataset, members ->
+	members.each { member ->
+
+		def fullyQualifiedDsn = "$dataset($member)"
+		def filePath = "$tempLoadDir/$dataset"
+		new File(filePath).mkdirs()
+		def file = new File(filePath, member)
+
+		// set copyMode based on last level qualifier
+		currentCopyMode = copyModeMap[dataset.replaceAll(/.*\.([^.]*)/, "\$1")]
+		copy.setCopyMode(currentCopyMode)
+		copy.setDataset(dataset)
+
+		println "     Copying $dataset($member) to $filePath with DBB Copymode $currentCopyMode"
+		copy.dataset(dataset).member(member).file(file).execute()
+	}
+}
+
+def tarFile = new File("$props.workDir/${tarFileName}")
+
+println("** Creating tar file at $tarFile.")
+def processCmd = [
+	"sh",
+	"-c",
+	"tar cf $tarFile *"
+]
+
+def rc = runProcess(processCmd, tempLoadDir)
+assert rc == 0 : "Failed to package"
+
+//Package BuildReport.json to carry BuildInfo including deployTypes etc.
+println("** Adding BuildReport.json to $tarFile.")
+processCmd = [
+	"sh",
+	"-c",
+	"tar rf $tarFile BuildReport.json"
+]
+
+rc = runProcess(processCmd, new File(props.workDir))
+assert rc == 0 : "Failed to append BuildReport.json"
+
+println ("** Package successfully created at $tarFile.")
+
+//Set up the artifactory information to publish the tar file
+if (props.publish && props.publish.toBoolean()){
+	// Configuring ArtifactoryHelper parms
+	def String remotePath = (props.versionName) ? (props.versionName + "/" + tarFileName) : (tarFileLabel + "/" + tarFileName)
+	def url = new URI(props.get('artifactory.url') + "/" + props.get('artifactory.repo') + "/" + remotePath ).normalize().toString() // Normalized URL
+
+	def apiKey = props.'artifactory.user'
+	def user = props.'artifactory.user'
+	def password = props.'artifactory.password'
+	def repo = props.get('artifactory.repo') as String
+
+	//Call the ArtifactoryHelpers to publish the tar file
+	def scriptDir = new File(getClass().protectionDomain.codeSource.location.path).parent
+	File artifactoryHelpersFile = new File("$scriptDir/ArtifactoryHelpers.groovy")
+	Class artifactoryHelpersClass = new GroovyClassLoader(getClass().getClassLoader()).parseClass(artifactoryHelpersFile)
+	GroovyObject artifactoryHelpers = (GroovyObject) artifactoryHelpersClass.newInstance()
+	
+	println ("** Uploading package to Artifactory $url.")
+	artifactoryHelpers.upload(url, tarFile as String, user, password, props.verbose.toBoolean() )
+	}
+
+/**
+ * parse data set name and member name
+ * @param fullname e.g. BLD.LOAD(PGM1)
+ * @return e.g. (BLD.LOAD, PGM1)
+ */
+def getDatasetName(String fullname){
+	def ds,member;
+	def elements =  fullname.split("[\\(\\)]");
+	ds = elements[0];
+	member = elements.size()>1? elements[1] : "";
+	return [ds, member];
+}
+
+/**
+ * run process
+ */
+def runProcess(ArrayList cmd, File dir){
+	if (props.verbose) println "executing $cmd: "
+	StringBuffer response = new StringBuffer()
+	StringBuffer error = new StringBuffer()
+
+	// execute cmd
+	def p = cmd.execute(null, dir)
+
+	p.waitForProcessOutput(response, error)
+	println(response.toString())
+
+	def rc = p.exitValue();
+	if(rc==0){
+
+	}else{
+		println("*! Error executing $cmd \n" + error.toString())
+		//System.exit(rc)
+	}
+	return rc
+}
+
+/**
+ * read cliArgs
+ */
+def parseInput(String[] cliArgs){
+	def cli = new CliBuilder(usage: "PackageBuildOutputs.groovy [options]")
+	cli.w(longOpt:'workDir', args:1, argName:'dir', 'Absolute path to the DBB build output directory')
+	cli.v(longOpt:'versionName', args:1, argName:'versionName', 'Name of the package tar file (Optional)')
+	cli.p(longOpt:'publish', 'Flag to indicate package upload to the provided Artifactory server. (Optional)')
+	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFile', 'Absolute path of a property file containing application specific Artifactory details. (Optional)')
+	cli.verb(longOpt:'verbose', 'Flag to provide more log output. (Optional)')
+
+	cli.h(longOpt:'help', 'Prints this message')
+	def opts = cli.parse(cliArgs)
+	if (opts.h) { // if help option used, print usage and exit
+		cli.usage()
+		System.exit(0)
+	}
+
+	def props = new Properties()
+
+	// set command line arguments
+	if (opts.w) props.workDir = opts.w
+
+	// Optional parms
+	if (opts.v) props.versionName = opts.v
+	
+	props.publish = (opts.p) ? 'true' : 'false'
+	props.verbose = (opts.verb) ? 'true' : 'false'
+	
+	if (opts.prop){
+		def propertyFile = new File(opts.prop)
+		if (propertyFile.exists()){
+			propertyFile.withInputStream { props.load(it) }
+		}
+	}
+
+	// validate required props
+	try {
+		assert props.workDir : "Missing property build work directory"
+		if (props.publish && props.publish.toBoolean()){
+			assert props.get("artifactory.url") : "Missing Artifactory URL"
+			assert props.get("artifactory.repo") : "Missing Artifactory Repository"
+			assert props.get("artifactory.user") : "Missing Artifactory Username"
+			assert props.get("artifactory.password") : "Missing Artifactory Password"
+		}
+
+	} catch (AssertionError e) {
+		cli.usage()
+		throw e
+	}
+	return props
+}

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -5,13 +5,13 @@ Another area, where this script is beneficial as a sample, is to adapt this scri
 The ArtifactoryHelpers allow you to upload and download packages from Artifactory. The ArtifactoryHelpers are a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
 
 ## Prerequisites
-'PackageBuildOutputs.groovy' is a sample of an post-build sample and relies on the a DBB Build Report as an input .
+`PackageBuildOutputs.groovy` is a sample of an post-build sample and relies on the a DBB Build Report as an input .
 
 ## Package Build Outputs
 
 ### Packaging
 
-1. After a successful DBB build, 'PackageBuildOutputs.groovy' reads the build report and retrieves all outputs from the build report. It excludes outputs without a `deployType` as well as those labeled `ZUNIT-TESTCASE` 
+1. After a successful DBB build, `PackageBuildOutputs.groovy` reads the build report and retrieves all outputs from the build report. It excludes outputs without a `deployType` as well as those labeled `ZUNIT-TESTCASE` 
 2. It then invokes CopyToHFS to copy the outputs from the libraries to a temporary directory on zFS. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS  
 3. It packages these load files into a tar file, and adds the BuildReport.json to it.
 

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -15,7 +15,7 @@ The ArtifactoryHelpers is a very simple implementation sufficient for a show cas
 ### Packaging
 
 1. After a successful DBB build, `PackageBuildOutputs.groovy` reads the build report and retrieves all outputs from the build report. It excludes outputs without a `deployType` as well as those labeled `ZUNIT-TESTCASE` 
-2. It then invokes CopyToHFS to copy the outputs from the libraries to a temporary directory on zFS. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS  
+2. It then invokes CopyToHFS API to copy the outputs from the libraries to a temporary directory on zFS. It will set the file tags based on the ZLANG setting (Note: A workaround is implemented to tag files as binary); all files require to be tagged. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS.  
 3. It packages these load files into a tar file, and adds the BuildReport.json to it.
 4. (Optional) Publishes the tar file to the Artifactory repository based on the given configuration using the ArtifactoryHelpers.
 
@@ -105,8 +105,6 @@ groovyz  /var/jenkins/pipeline/ArtifactoryHelpers.groovy --url http://10.3.20.23
  
 ```
 
-
-
 ## Command Line Options Summary - PackageBuildOutputs
 
 ```
@@ -150,4 +148,20 @@ usage: ArtifactoryHelpers.groovy [options]
  -u,--url <arg>               Artifactory file uri location
  -U,--user <arg>              Artifactory user id
  -v,--verbose                 Flag to turn on script trace
+```
+
+
+## Useful reference material
+
+This sample implementation makes use of tar on USS.
+Please see IBM Docs for further details on [tar](https://www.ibm.com/docs/en/zos/2.4.0?topic=scd-tar-manipulate-tar-archive-files-copy-back-up-file)
+
+The implementation preserves the file tags for further processing.
+
+```
+tar -tvf justloads.jar -L T
+USTAR Version 00
+                    drwxr-xr-x   1 BPXROOT  DB2USR         0 Jul 28 13:47 JENKINS.DBB.SAMP.BUILD.LOAD/
+b binary      T=off -rwxr-xr-x   1 BPXROOT  DB2USR     32768 Jul 28 13:47 JENKINS.DBB.SAMP.BUILD.LOAD/EPSMPMT
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  DB2USR     18326 Jul 28 13:47 BuildReport.json
 ```

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to create a tar-file with the build outputs based on the DBB Build Report after a successful build.
 
-The package can be uploaded to an artifact repository and used in a scripted deployment. Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository and tp pull them into the build process.
+The package can be uploaded to an artifact repository and used in a scripted deployment. Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository and to pull them into the build process.
 The `ArtifactoryHelpers.groovy` allow you to upload and download packages from Artifactory. 
 
 The ArtifactoryHelpers is a very simple implementation sufficient for a show case, **_we recommend_** to use the Artifactory publishers which are available with your CI pipeline coordinator.

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -3,7 +3,9 @@
 This sample shows how to create a tar-file with the build outputs based on the DBB Build Report after a successful build.
 
 The package can be uploaded to an artifact repository and used in a scripted deployment. Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository and tp pull them into the build process.
-The `ArtifactoryHelpers.groovy` allow you to upload and download packages from Artifactory. The ArtifactoryHelpers are a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
+The `ArtifactoryHelpers.groovy` allow you to upload and download packages from Artifactory. 
+
+The ArtifactoryHelpers is a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
 
 ## Prerequisites
 `PackageBuildOutputs.groovy` is a sample of an post-build script relying at least on the a DBB Build Report as an input.
@@ -17,12 +19,7 @@ The `ArtifactoryHelpers.groovy` allow you to upload and download packages from A
 3. It packages these load files into a tar file, and adds the BuildReport.json to it.
 4. (Optional) Publishes the tar file to the Artifactory repository based on the given configuration using the ArtifactoryHelpers.
 
-## Package Upload and Download
-`ArtifactoryHelpers.groovy` allow uploading and downloading a package to Artifactory. 
-
-### 
-
-## Sample Invocation
+## Invocation samples 
 
 ### Package only
 ```

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -5,7 +5,7 @@ This sample shows how to create a tar-file with the build outputs based on the D
 The package can be uploaded to an artifact repository and used in a scripted deployment. Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository and tp pull them into the build process.
 The `ArtifactoryHelpers.groovy` allow you to upload and download packages from Artifactory. 
 
-The ArtifactoryHelpers is a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
+The ArtifactoryHelpers is a very simple implementation sufficient for a show case, **_we recommend_** to use the Artifactory publishers which are available with your CI pipeline coordinator.
 
 ## Prerequisites
 `PackageBuildOutputs.groovy` is a sample of an post-build script relying at least on the a DBB Build Report as an input.
@@ -24,7 +24,6 @@ The ArtifactoryHelpers is a very simple implementation sufficient for a show cas
 ### Package only
 ```
 groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005
-
 
 ** PackageBuildOutputs start at 20210726.051010.010
 ** Properties at startup:
@@ -53,40 +52,44 @@ groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/
 
 ### Package and Publish to Artifactory
 ```
-groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005 --propertyFile /var/jenkins/pipeline/publish.properties -v MortgageRelease_1.0 --verbose --publish
+groovyz /var/jenkins/pipeline/PublishLoadModule.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034 --propertyFile publish.properties -v MortgageRelease_1.0 -t myPackage.tar --verbose --publish
 
 
-** PackageBuildOutputs start at 20210726.050608.006
+** PackageBuildOutputs start at 20210727.042032.020
 ** Properties at startup:
-   workDir -> /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005
-   startTime -> 20210726.050608.006
+   workDir -> /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034
+   startTime -> 20210727.042032.020
    publish -> true
    versionName -> MortgageRelease_1.0
-   verbose -> true
+   verbose -> false
    artifactory.password -> xxxxx
    artifactory.user -> xxxxx
    artifactory.repo -> basicRepository
+   tarFileName -> myPackage.tar
    artifactory.url -> http://10.3.20.231:8081/artifactory
-** Read build report data from /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/BuildReport.json
+** Read build report data from /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/BuildReport.json
+** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
 ** Copying BuildOutputs to temporary package dir.
 *** Number of build outputs to publish: 10
-     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
-     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
-** Creating tar file at /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
-** Adding BuildReport.json to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
-** Package successfully created at /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
-** Uploading package to Artifactory http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/build.20210726.050505.005.tar.
+     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
+     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
+** Creating tar file at /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/myPackage.tar.
+
+** Adding BuildReport.json to /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/myPackage.tar.
+
+** Package successfully created at /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034/myPackage.tar.
+** Uploading package to Artifactory http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/myPackage.tar.
 ** Headers: [Expect: 100-continue, Connection: Keep-Alive]
-** Request: PUT http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/build.20210726.050505.005.tar HTTP/1.1
-** Response: HttpResponseProxy{HTTP/1.1 201 Created [Server: Artifactory/6.6.5, X-Artifactory-Id: 6e0b564c45b20ed4:-57a85152:1783ac71376:-8000, Location: http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/build.20210726.050505.005.tar, Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1, Transfer-Encoding: chunked, Date: Mon, 26 Jul 2021 16:06:10 GMT] ResponseEntityProxy{[Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1,Chunked: true]}}
+** Request: PUT http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/myPackage.tar HTTP/1.1
+** Response: HttpResponseProxy{HTTP/1.1 201 Created [Server: Artifactory/6.6.5, X-Artifactory-Id: 6e0b564c45b20ed4:-57a85152:1783ac71376:-8000, Location: http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/myPackage.tar, Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1, Transfer-Encoding: chunked, Date: Tue, 27 Jul 2021 15:20:34 GMT] ResponseEntityProxy{[Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1,Chunked: true]}}
 ** Build finished
 ```
 
@@ -111,17 +114,25 @@ usage: PackageBuildOutputs.groovy [options]
 
  -w,--workDir <dir>                    Absolute path to the DBB build
                                        output directory
-Optional: 
-                                      
+
+Optional:
+ -t,--tarFileName <filename>           Name of the package tar file.
+                                       (Optional)
+ -d,--deployTypes <deployTypes>        Comma-seperated list of deployTypes
+                                       to filter on the scope of the tar
+                                       file. (Optional)
+ -verb,--verbose                       Flag to provide more log output.
+                                       (Optional)
+                                       
+Artifactory Upload Options
+
  -p,--publish                          Flag to indicate package upload to
                                        the provided Artifactory server.
                                        (Optional)
  -prop,--propertyFile <propertyFile>   Absolute path of a property file
                                        containing application specific
                                        Artifactory details. (Optional)
- -v,--versionName <versionName>        Name of the package tar file
-                                       (Optional)
- -verb,--verbose                       Flag to provide more log output.
+ -v,--versionName <versionName>        Name of the Artifactory version.
                                        (Optional)
 
  -h,--help                             Prints this message

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -1,22 +1,26 @@
-# Package Build Outputs in an independent tar format
-This sample shows how to create a tar-file with the build outputs based on the DBB Build Report after a successful build, which can be published to an artifact repository and used in a scripted deployment.
-Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository. 
+# Package Build Outputs in tar format
 
-The ArtifactoryHelpers allow you to upload and download packages from Artifactory. The ArtifactoryHelpers are a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
+This sample shows how to create a tar-file with the build outputs based on the DBB Build Report after a successful build.
+
+The package can be uploaded to an artifact repository and used in a scripted deployment. Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository and tp pull them into the build process.
+The `ArtifactoryHelpers.groovy` allow you to upload and download packages from Artifactory. The ArtifactoryHelpers are a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
 
 ## Prerequisites
-`PackageBuildOutputs.groovy` is a sample of an post-build sample and relies on the a DBB Build Report as an input .
+`PackageBuildOutputs.groovy` is a sample of an post-build script relying at least on the a DBB Build Report as an input.
 
-## Package Build Outputs
+## Package Build Outputs Process
 
 ### Packaging
 
 1. After a successful DBB build, `PackageBuildOutputs.groovy` reads the build report and retrieves all outputs from the build report. It excludes outputs without a `deployType` as well as those labeled `ZUNIT-TESTCASE` 
 2. It then invokes CopyToHFS to copy the outputs from the libraries to a temporary directory on zFS. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS  
 3. It packages these load files into a tar file, and adds the BuildReport.json to it.
+4. (Optional) Publishes the tar file to the Artifactory repository based on the given configuration using the ArtifactoryHelpers.
 
-### (Optional) Uploading package
-4. Publishes the tar file to the Artifactory repository based on the given configuration.
+## Package Upload and Download
+`ArtifactoryHelpers.groovy` allow uploading and downloading a package to Artifactory. 
+
+### 
 
 ## Sample Invocation
 
@@ -89,9 +93,21 @@ groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/
 ** Build finished
 ```
 
+### Only Upload or Download to/from Artifactory
+
+```
+groovyz  /var/jenkins/pipeline/ArtifactoryHelpers.groovy --url http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.1/build.20210727.073406.034.tar --user xxxxx --password xxxxx --fileToUpload /var/jenkins/workspace/MortgageApplication//build.20210727.073406.034.tar --verbose
+
+** Headers: [Expect: 100-continue, Connection: Keep-Alive]
+** Request: PUT http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.1/build.20210727.073406.034.tar HTTP/1.1
+** Response: HttpResponseProxy{HTTP/1.1 201 Created [Server: Artifactory/6.6.5, X-Artifactory-Id: 6e0b564c45b20ed4:-57a85152:1783ac71376:-8000, Location: http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.1/build.20210727.073406.034.tar, Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1, Transfer-Encoding: chunked, Date: Tue, 27 Jul 2021 06:37:30 GMT] ResponseEntityProxy{[Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1,Chunked: true]}}
+** Build finished
+ 
+```
 
 
-## Command Line Options Summary
+
+## Command Line Options Summary - PackageBuildOutputs
 
 ```
 usage: PackageBuildOutputs.groovy [options]
@@ -112,4 +128,18 @@ Optional:
                                        (Optional)
 
  -h,--help                             Prints this message
+```
+
+## Command Line Options Summary - ArtifactoryHelpers
+
+```
+usage: ArtifactoryHelpers.groovy [options]
+
+ -fD,--fileToDownload <arg>   The full path of the file to download
+ -fU,--fileToUpload <arg>     The full path of the file to upload
+ -h,--help                    Prints this message
+ -P,--password <arg>          Artifactory password
+ -u,--url <arg>               Artifactory file uri location
+ -U,--user <arg>              Artifactory user id
+ -v,--verbose                 Flag to turn on script trace
 ```

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -1,0 +1,115 @@
+# Package Build Outputs in an independent tar format
+This sample shows how to create a tar-file with the build outputs based on the DBB Build Report after a successful build, which can be published to an artifact repository and used in a scripted deployment.
+Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository. 
+
+The ArtifactoryHelpers allow you to upload and download packages from Artifactory. The ArtifactoryHelpers are a very simple implementation sufficient for a show case, we recommend to rather use the Artifactory Publishers which are available by your CI pipeline coordinator.
+
+## Prerequisites
+'PackageBuildOutputs.groovy' is a sample of an post-build sample and relies on the a DBB Build Report as an input .
+
+## Package Build Outputs
+
+### Packaging
+
+1. After a successful DBB build, 'PackageBuildOutputs.groovy' reads the build report and retrieves all outputs from the build report. It excludes outputs without a `deployType` as well as those labeled `ZUNIT-TESTCASE` 
+2. It then invokes CopyToHFS to copy the outputs from the libraries to a temporary directory on zFS. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS  
+3. It packages these load files into a tar file, and adds the BuildReport.json to it.
+
+### (Optional) Uploading package
+4. Publishes the tar file to the Artifactory repository based on the given configuration.
+
+## Sample Invocation
+
+### Package only
+```
+groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005
+
+
+** PackageBuildOutputs start at 20210726.051010.010
+** Properties at startup:
+   verbose -> false
+   startTime -> 20210726.051010.010
+   publish -> false
+   workDir -> /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005
+** Read build report data from /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/BuildReport.json
+** Copying BuildOutputs to temporary package dir.
+*** Number of build outputs to publish: 10
+     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
+     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
+** Creating tar file at /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
+** Adding BuildReport.json to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
+** Package successfully created at /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
+** Build finished
+```
+
+### Package and Publish to Artifactory
+```
+groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005 --propertyFile /var/jenkins/pipeline/publish.properties -v MortgageRelease_1.0 --verbose --publish
+
+
+** PackageBuildOutputs start at 20210726.050608.006
+** Properties at startup:
+   workDir -> /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005
+   startTime -> 20210726.050608.006
+   publish -> true
+   versionName -> MortgageRelease_1.0
+   verbose -> true
+   artifactory.password -> xxxxx
+   artifactory.user -> xxxxx
+   artifactory.repo -> basicRepository
+   artifactory.url -> http://10.3.20.231:8081/artifactory
+** Read build report data from /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/BuildReport.json
+** Copying BuildOutputs to temporary package dir.
+*** Number of build outputs to publish: 10
+     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
+     Copying JENKINS.DBB.SAMP.BUILD.BMS.COPY(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.BMS.COPY with DBB Copymode TEXT
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
+** Creating tar file at /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
+** Adding BuildReport.json to /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
+** Package successfully created at /var/jenkins/workspace/MortgageApplication/build.20210726.050505.005/build.20210726.050505.005.tar.
+** Uploading package to Artifactory http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/build.20210726.050505.005.tar.
+** Headers: [Expect: 100-continue, Connection: Keep-Alive]
+** Request: PUT http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/build.20210726.050505.005.tar HTTP/1.1
+** Response: HttpResponseProxy{HTTP/1.1 201 Created [Server: Artifactory/6.6.5, X-Artifactory-Id: 6e0b564c45b20ed4:-57a85152:1783ac71376:-8000, Location: http://10.3.20.231:8081/artifactory/basicRepository/MortgageRelease_1.0/build.20210726.050505.005.tar, Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1, Transfer-Encoding: chunked, Date: Mon, 26 Jul 2021 16:06:10 GMT] ResponseEntityProxy{[Content-Type: application/vnd.org.jfrog.artifactory.storage.ItemCreated+json;charset=ISO-8859-1,Chunked: true]}}
+** Build finished
+```
+
+
+
+## Command Line Options Summary
+
+```
+usage: PackageBuildOutputs.groovy [options]
+
+ -w,--workDir <dir>                    Absolute path to the DBB build
+                                       output directory
+Optional: 
+                                      
+ -p,--publish                          Flag to indicate package upload to
+                                       the provided Artifactory server.
+                                       (Optional)
+ -prop,--propertyFile <propertyFile>   Absolute path of a property file
+                                       containing application specific
+                                       Artifactory details. (Optional)
+ -v,--versionName <versionName>        Name of the package tar file
+                                       (Optional)
+ -verb,--verbose                       Flag to provide more log output.
+                                       (Optional)
+
+ -h,--help                             Prints this message
+```

--- a/Pipeline/PackageBuildOutputs/appArtifactory.properties
+++ b/Pipeline/PackageBuildOutputs/appArtifactory.properties
@@ -1,4 +1,14 @@
-artifactory.url=http://10.3.20.231:8081/artifactory
-artifactory.repo=basicRepository
-artifactory.user=admin
-artifactory.password=artifactoryadmin
+########################################################################
+### The following properties are required for publishing a package 
+### containing build outputs to an Artifactory Server.  
+########################################################################
+
+# The URL to the Artifactory Server
+artifactory.url=https://your-artifactory-url/artifactory
+
+# The Artifactory repository to store the build 
+artifactory.repo=sys-zos-application-local
+
+# Artifactory credentials
+artifactory.user=
+artifactory.password=

--- a/Pipeline/PackageBuildOutputs/appArtifactory.properties
+++ b/Pipeline/PackageBuildOutputs/appArtifactory.properties
@@ -1,0 +1,4 @@
+artifactory.url=http://10.3.20.231:8081/artifactory
+artifactory.repo=basicRepository
+artifactory.user=admin
+artifactory.password=artifactoryadmin

--- a/Pipeline/README.md
+++ b/Pipeline/README.md
@@ -6,5 +6,6 @@ Sample | Description | Documentation Link
 --- | --- | ---
 CreateUCDComponentVersion | This sample reads the DBB Build Report to generate a UCD Shiplist and to run the BUZTOOL.sh command to create a new UCD Component version. Both Codestation and the external Artifact Repository is supported. | [CreateUCDComponentVersion/README.md](CreateUCDComponentVersion/README.md)
 DeployUCDComponentVersion | This sample can be use to deploy an application component version into a specific environment. | [DeployUCDComponentVersion/README.md](DeployUCDComponentVersion/README.md)
+PublishBuildOutputs | This sample creates a TAR file with the build outputs referenced in a DBB Build Report. Additionally, it contains a sample to Upload/Download to Artifactory. | [PublishBuildOutputs/README.md](PublishBuildOutputs/README.md)
 RunIDZCodeReview | This sample reads the DBB Build Report, assembles an JCL to run IDZ Code Review on Z/OS in Batch. | [RunIDZCodeReview/README.md](RunIDZCodeReview/README.md)
 PublishSharedInterfaces | This sample script implements a publishing mechanism of interfaces to a common git repository for shared interfaces. | [PublishSharedInterfaces/README.md](PublishSharedInterfaces/README.md)


### PR DESCRIPTION
This PR ships a new pipeline sample to package the produced build outputs from a build with Dependency Based Build into a generic TAR file.

It contains of two parts:
- Packaging build outputs based after a successful DBB build
- ArtifactoryHelpers (as CLI or within code ) as a sample to upload or download to Artifactory.

However, as mentioned in the README, we recommend to leverage the existing Artifactory plugins available with your pipeline orchestrator.

It supersedes the existing PublishLoadModules script.