### PR TITLE
Enhancement to the WebAppCleanup script

### DIFF
--- a/Utilities/WebAppCleanUp/README.md
+++ b/Utilities/WebAppCleanUp/README.md
@@ -39,7 +39,8 @@ MortgageApplication-Bug1220-outputs
 ```
 
 ### Web Application Authentication Properties
-The `user.properties` file has been provided for a convienient place to store DBB Web Application authentication properties.  However its use is optional as the user can  provide the required authentication values as script arguments.  Example:
+A property file can be specified through the --prop parameter. This property file can stored DBB Web Application authentication properties. A sample property file `user.properties` is supplied along this script. 
+ However its use is optional as the user can provide the required authentication values as script arguments.  Example:
 ```
 $DBB_HOME/bin/groovyz WebAppCleanUp.groovy --groups Application-FeatureBranch --url https://localhost:9443/dbb --id ADMIN --pw ADMIN
 ``` 
@@ -62,6 +63,9 @@ options:
  -i,--id <arg>                DBB WebApp ID
  -p,--pw <arg>                DBB WebApp Password
  -P,--pwFile <arg>            Absolute or relative (from this script) path
-                              to file containing DBB password
+                              to file containing DBB password   
+ -prop,--propertyFile <arg>   Absolute or relative (from this script) path
+                              to property file that contains DBB WebApp
+                              information (Optional)                                                 
  -u,--url <arg>               DBB WebApp URL
 ```

--- a/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
+++ b/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
@@ -52,8 +52,9 @@ def setup(String[] args) {
 	cli.i(longOpt:'id', args:1, 'DBB WebApp ID')
 	cli.p(longOpt:'pw', args:1,  'DBB WebApp Password')
 	cli.P(longOpt:'pwFile', args:1, 'Absolute or relative (from this script) path to file containing DBB password')
-	cli.h(longOpt:'help', 'Prints this message')
-	
+	cli.prop(longOpt:'propertyFile', args:1, 'Absolute path to property file that contains DBB WebApp information (Optional)')	
+
+		cli.h(longOpt:'help', 'Prints this message')
 	def opts = cli.parse(args)
 	if (!args || !opts) {
 	    cli.usage()
@@ -66,8 +67,9 @@ def setup(String[] args) {
 		System.exit(0)
 	}
 
-    // load user properties file
-   	properties.load(new File("${getScriptDir()}/user.properties"))
+	// if specified, load user properties file
+	if (opts.prop)
+   		properties.load(new File("${opts.prop}"))
    	
    	// update authentication properties with cli options
    	if (opts.u) properties.url = opts.url

--- a/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
+++ b/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
@@ -32,7 +32,7 @@ collections.each { collection ->
 
 /*
   setup :
-  handle cli arguments, load WebAppCleanUp.properties file, 
+  handle cli arguments, load property file if present, 
   create repository client, populate deletion lists
 */
 def setup(String[] args) {
@@ -52,7 +52,7 @@ def setup(String[] args) {
 	cli.i(longOpt:'id', args:1, 'DBB WebApp ID')
 	cli.p(longOpt:'pw', args:1,  'DBB WebApp Password')
 	cli.P(longOpt:'pwFile', args:1, 'Absolute or relative (from this script) path to file containing DBB password')
-	cli.prop(longOpt:'propertyFile', args:1, 'Absolute path to property file that contains DBB WebApp information (Optional)')	
+	cli.prop(longOpt:'propertyFile', args:1, 'Absolute or relative (from this script) path to property file that contains DBB WebApp information (Optional)')	
 
 		cli.h(longOpt:'help', 'Prints this message')
 	def opts = cli.parse(args)

--- a/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
+++ b/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
@@ -54,8 +54,7 @@ def setup(String[] args) {
 	cli.P(longOpt:'pwFile', args:1, 'Absolute or relative (from this script) path to file containing DBB password')
 	cli.prop(longOpt:'propertyFile', args:1, 'Absolute or relative (from this script) path to property file that contains DBB WebApp information (Optional)')	
 
-	cli.h(longOpt:'help', 'Prints this message')
-	
+		cli.h(longOpt:'help', 'Prints this message')
 	def opts = cli.parse(args)
 	if (!args || !opts) {
 	    cli.usage()
@@ -68,10 +67,14 @@ def setup(String[] args) {
 		System.exit(0)
 	}
 
-	// if specified, load the specified properties file
-	if (opts.prop)
-   		properties.load(new File("${opts.prop}"))
-   	
+	// if specified, load user properties file
+	if (opts.prop) {
+		String filePath = opts.prop
+		if (!filePath.trim().startsWith('/'))
+			filePath = "${getScriptDir()}/$filePath"
+		properties.load(new File(filePath))
+	}
+
    	// update authentication properties with cli options
    	if (opts.u) properties.url = opts.url
    	if (opts.i) properties.id = opts.id

--- a/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
+++ b/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
@@ -54,7 +54,8 @@ def setup(String[] args) {
 	cli.P(longOpt:'pwFile', args:1, 'Absolute or relative (from this script) path to file containing DBB password')
 	cli.prop(longOpt:'propertyFile', args:1, 'Absolute or relative (from this script) path to property file that contains DBB WebApp information (Optional)')	
 
-		cli.h(longOpt:'help', 'Prints this message')
+	cli.h(longOpt:'help', 'Prints this message')
+	
 	def opts = cli.parse(args)
 	if (!args || !opts) {
 	    cli.usage()
@@ -67,7 +68,7 @@ def setup(String[] args) {
 		System.exit(0)
 	}
 
-	// if specified, load user properties file
+	// if specified, load the specified properties file
 	if (opts.prop)
    		properties.load(new File("${opts.prop}"))
    	


### PR DESCRIPTION
This enhancement is to support passing a file which contains DBB WebApp information. Using the --prop parameter, user can supply the absolute or relative path to a file that contains the necessary information to connect to the DBB WebApp server. The values in the file can still be overiden by CLI options (--url, --id, --pw, --pwFile).
The property file 'user.properties' is the valid sample file to be customized and to be used in the --prop parameter.