### PR TITLE
Add support for DeletePDS script

### DIFF
--- a/Utilities/DeletePDS/DeletePDS.groovy
+++ b/Utilities/DeletePDS/DeletePDS.groovy
@@ -57,7 +57,7 @@ else
 */
 def setup(String[] args) {
 	// parse input arguments
-	String usage = 'deletePDS.groovy [options]'
+	String usage = 'DeletePDS.groovy [options]'
 	String header = 'options:'
 	def cli = new CliBuilder(usage:usage,header:header)
 	cli.h(longOpt:'hlq', args:1, 'High-Level Qualifier of datasets to delete')

--- a/Utilities/DeletePDS/DeletePDS.groovy
+++ b/Utilities/DeletePDS/DeletePDS.groovy
@@ -1,0 +1,76 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.transform.*
+import com.ibm.jzos.CatalogSearch;
+import com.ibm.jzos.CatalogSearchField;
+import com.ibm.jzos.ZFile;
+
+
+@Field String hlq
+@Field String filter
+@Field Boolean preview = false
+
+// run setup tasks
+setup(args)
+
+
+// process datasets with provided HLQ
+filter = hlq
+if (!filter.endsWith(".**"))
+	filter = filter + ".**"
+if (preview)
+	println("** Searching for all the datasets filtered with HLQ '${hlq}'")
+else
+	println("** Deleting all datasets filtered with HLQ '${hlq}'")
+
+
+CatalogSearch catalogSearch = new CatalogSearch(filter, 64000);
+catalogSearch.addFieldName("ENTNAME");
+catalogSearch.search();
+def datasetCount = 0
+
+catalogSearch.each { searchEntry ->
+	CatalogSearch.Entry catalogEntry = (CatalogSearch.Entry) searchEntry;
+	if (catalogEntry.isDatasetEntry()) {
+		datasetCount++;
+		CatalogSearchField field = catalogEntry.getField("ENTNAME");
+		String dsn = field.getFString().trim();
+		String qdsn = "'" + dsn + "'";	//Specify that the dsn is fully qualified.
+		if (ZFile.dsExists(qdsn)) {
+			if (preview) {
+				println "*** Found $qdsn"	
+			} else {
+				println "*** Deleting $qdsn"
+				ZFile.remove("//$qdsn")
+			}
+		 }
+	}
+}
+if (preview)
+	println("** Found $datasetCount entries.")
+else
+	println("** Deleted $datasetCount entries.")
+	
+
+/*
+ setup :
+ handle cli arguments
+*/
+def setup(String[] args) {
+	// parse input arguments
+	String usage = 'deletePDS.groovy [options]'
+	String header = 'options:'
+	def cli = new CliBuilder(usage:usage,header:header)
+	cli.h(longOpt:'hlq', args:1, 'High-Level Qualifier of datasets to delete')
+	cli.p(longOpt:'preview', 'Only lists the datasets without actually deleting them')
+	def opts = cli.parse(args)
+	if (!args || !opts) {
+		cli.usage()
+		System.exit(1)
+	}
+	   
+	// update authentication properties with cli options
+	if (opts.h) hlq = opts.h
+	if (opts.p) preview = opts.p
+	
+	assert hlq : "Missing 'hlq' argument"
+}

--- a/Utilities/DeletePDS/README.md
+++ b/Utilities/DeletePDS/README.md
@@ -1,0 +1,69 @@
+# DeletePDS Utility
+
+The DeletePDS utility is used to delete PDSes on z/OS that are no longer needed.
+Typically, after a build in a feature branch where datasets where created for the build, clean-up should occur to limit and optimize the required storage space on z/OS.
+
+To delete datasets with the DeletePDS utility, you would need to specify the parameter `-h`/`--hlq` to indicate the High-Level Qualifier for your datasets to be deleted. This value is used as a filter expression for identifying the datasets to be deleted.
+
+An other parameter `-p`/`--preview` is helpful to verify which datasets are to be deleted. Using this parameter will just display the datasets that matches the filter expression passed in - HLQ paramater of the script.
+
+
+Preview:
+``` 
+$DBB_HOME/bin/groovyz DeletePDS.groovy -p -h BUILD.CATMAN.DEV
+```
+Output:
+```
+** Searching for all the datasets filtered with HLQ 'BUILD.CATMAN.DEV'
+*** Found 'BUILD.CATMAN.DEV.ASM'
+*** Found 'BUILD.CATMAN.DEV.BMS'
+*** Found 'BUILD.CATMAN.DEV.BMS.COPY'
+*** Found 'BUILD.CATMAN.DEV.BZU.BZUCFG'
+*** Found 'BUILD.CATMAN.DEV.BZU.BZUPLAY'
+*** Found 'BUILD.CATMAN.DEV.BZU.BZURPT'
+*** Found 'BUILD.CATMAN.DEV.COBOL'
+*** Found 'BUILD.CATMAN.DEV.COPY'
+*** Found 'BUILD.CATMAN.DEV.DBRM'
+*** Found 'BUILD.CATMAN.DEV.LOAD'
+*** Found 'BUILD.CATMAN.DEV.MACRO'
+*** Found 'BUILD.CATMAN.DEV.OBJ'
+*** Found 'BUILD.CATMAN.DEV.TEST.COBOL'
+*** Found 'BUILD.CATMAN.DEV.TEST.LOAD'
+** Found 14 entries.
+** Build finished
+```
+
+Deletion:
+``` 
+$DBB_HOME/bin/groovyz DeletePDS.groovy -h BUILD.CATMAN.DEV
+```
+Output:
+```
+** Deleting all datasets filtered with HLQ 'BUILD.CATMAN.DEV'
+*** Deleting 'BUILD.CATMAN.DEV.ASM'
+*** Deleting 'BUILD.CATMAN.DEV.BMS'
+*** Deleting 'BUILD.CATMAN.DEV.BMS.COPY'
+*** Deleting 'BUILD.CATMAN.DEV.BZU.BZUCFG'
+*** Deleting 'BUILD.CATMAN.DEV.BZU.BZUPLAY'
+*** Deleting 'BUILD.CATMAN.DEV.BZU.BZURPT'
+*** Deleting 'BUILD.CATMAN.DEV.COBOL'
+*** Deleting 'BUILD.CATMAN.DEV.COPY'
+*** Deleting 'BUILD.CATMAN.DEV.DBRM'
+*** Deleting 'BUILD.CATMAN.DEV.LOAD'
+*** Deleting 'BUILD.CATMAN.DEV.MACRO'
+*** Deleting 'BUILD.CATMAN.DEV.OBJ'
+*** Deleting 'BUILD.CATMAN.DEV.TEST.COBOL'
+*** Deleting 'BUILD.CATMAN.DEV.TEST.LOAD'
+** Deleted 14 entries.
+** Build finished
+```
+
+
+
+### Delete.groovy Command Line Options
+```
+usage: DeletePDS.groovy [options]
+options:
+ -h,--hlq <arg>   High-Level Qualifier of datasets to delete
+ -p,--preview     Only lists the datasets without actually deleting them
+```

--- a/Utilities/DeletePDS/README.md
+++ b/Utilities/DeletePDS/README.md
@@ -1,7 +1,7 @@
 # DeletePDS Utility
 
 The DeletePDS utility is used to delete PDSes on z/OS that are no longer needed.
-Typically, after a build in a feature branch where datasets where created for the build, clean-up should occur to limit and optimize the required storage space on z/OS.
+Typically, after a build in a feature branch where datasets were created for the build, clean-up should occur to limit and optimize the required storage space on z/OS.
 
 To delete datasets with the DeletePDS utility, you would need to specify the parameter `-h`/`--hlq` to indicate the High-Level Qualifier for your datasets to be deleted. This value is used as a filter expression for identifying the datasets to be deleted.
 

--- a/Utilities/DeletePDS/README.md
+++ b/Utilities/DeletePDS/README.md
@@ -5,7 +5,7 @@ Typically, after a build in a feature branch where datasets where created for th
 
 To delete datasets with the DeletePDS utility, you would need to specify the parameter `-h`/`--hlq` to indicate the High-Level Qualifier for your datasets to be deleted. This value is used as a filter expression for identifying the datasets to be deleted.
 
-An other parameter `-p`/`--preview` is helpful to verify which datasets are to be deleted. Using this parameter will just display the datasets that matches the filter expression passed in - HLQ paramater of the script.
+An other parameter `-p`/`--preview` is helpful to verify which datasets are to be deleted. Using this parameter will just display the datasets that matches the filter expression passed in the HLQ parameter of the script.
 
 
 Preview:
@@ -60,7 +60,7 @@ Output:
 
 
 
-### Delete.groovy Command Line Options
+### DeletePDS.groovy Command Line Options
 ```
 usage: DeletePDS.groovy [options]
 options:


### PR DESCRIPTION
The DeletePDS script can be used to delete datasets that matches the HLQ parameter given as input.
When a preview flag is set, the utility just lists the datasets that match the HLQ parameter.