### PR TITLE
Bugfix on PackageBuildOutputs on parsing fullBuild Log

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -118,13 +118,10 @@ else {
 		} catch (Exception e){}
 	}
 
-	if (buildInfo.size() == 0){
-		def String tarFileLabel = "fullBuild"
-		def String buildGroup = "buildGroup"
-	}
-	else {
-		def String tarFileLabel = buildInfo[0].label
-		def String buildGroup = buildInfo[0].group
+	def String tarFileLabel = "fullBuild"
+
+	if (buildInfo.size() != 0) {
+		tarFileLabel = buildInfo[0].label
 	}
 
 	def String tarFileName = (props.tarFileName) ? props.tarFileName : "${buildInfo[0].label}.tar"

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -118,9 +118,16 @@ else {
 		} catch (Exception e){}
 	}
 
-	def String tarFileLabel = buildInfo[0].label
+	if (buildInfo.size() == 0){
+		def String tarFileLabel = "fullBuild"
+		def String buildGroup = "buildGroup"
+	}
+	else {
+		def String tarFileLabel = buildInfo[0].label
+		def String buildGroup = buildInfo[0].group
+	}
+
 	def String tarFileName = (props.tarFileName) ? props.tarFileName : "${buildInfo[0].label}.tar"
-	def String buildGroup = buildInfo[0].group
 
 
 	//Create a temporary directory on zFS to copy the load modules from data sets to


### PR DESCRIPTION
Hi, I'm currently building a CI/CD for a mainframe project in Brazil.

Our DBB server was down last week, so I started working with fullbuild on our pipeline. Unfortunately when we package the artifacts a error emerged:

` Read build report data from /u/gds/gabcavl/workspace/ffac537e_1643646053/result/build.20220131.012121.021/BuildReport.json
 Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE 
Caught: java.lang.NullPointerException: Cannot get property 'label' on null object
java.lang.NullPointerException: Cannot get property 'label' on null object
        at PackageBuildOutputs.run(PackageBuildOutputs.groovy:121)`

It occurs because BuildReport.json for fullBuild does not have a dbbserver entry with BUILD_RESULT, like below:
`
        {
            "id": "BUILD_RESULT_1",
            "label": "build.20220128.110111.001",
            "type": "BUILD_RESULT",
            "url": "https://10.0.10.139:9443/dbb/rest/buildResult/3796",
            "group": "dbb-tests-main"
        },
`

This PR adds static names for label and buildGroup, but I personally don't know if it is the best strategy.