### PR TITLE
Refactor groovy scrips for Groovy 4.0.0 compatibility

### DIFF
--- a/Automation/idManagement/README.md
+++ b/Automation/idManagement/README.md
@@ -19,10 +19,6 @@ userdel - a groovy script that deletes a user from the system. It is meant to
           and alias.
 
 # Notes
-The groovy scripts in this folder rely on apache common cli to manage the
-command line arguments. You can download the apache common cli files from:
-https://commons.apache.org/proper/commons-cli/
-
 In each of the scripts there are two hardcoded definitions that must be
 modified prior to use. You will find:
 a DDStatement with ("HLQ.ISPFGWY.EXEC") specification. The HLQ must be modified

--- a/Automation/idManagement/useradd.groovy
+++ b/Automation/idManagement/useradd.groovy
@@ -2,9 +2,6 @@
 //* useradd:                                                                              *
 //*         Add a user to the system                                                      *
 //*                                                                                       *
-//* Dependencies:                                                                         *
-//*              apache commons cli (https://commons.apache.org/proper/commons-cli/)      *
-//*              this not only handles the arguments for the add, it does the documention *
 //*                                                                                       *
 //* Additional Components:                                                                *
 //*              useradd.properties - a file that holds the defaults for adding a user    *

--- a/Automation/idManagement/useradd.groovy
+++ b/Automation/idManagement/useradd.groovy
@@ -12,7 +12,7 @@
 //*                                   defaults for different user types.                  *
 //*****************************************************************************************
 import com.ibm.dbb.build.*
-import org.apache.commons.cli.*
+import groovy.cli.commons.*
 
 // Take input and define any overrides to the defaults
 def cli= new CliBuilder(usage: 'useradd -u userid -n "users name"')

--- a/Automation/idManagement/userdel.groovy
+++ b/Automation/idManagement/userdel.groovy
@@ -2,9 +2,6 @@
 //* usedel:                                                                               *
 //*         Remove a user from the system                                                 *
 //*                                                                                       *
-//* Dependencies:                                                                         *
-//*              apache commons cli (https://commons.apache.org/proper/commons-cli/)      *
-//*              this not only handles the arguments for the add, it does the documention *
 //*                                                                                       *
 //*****************************************************************************************
 import com.ibm.dbb.build.*

--- a/Automation/idManagement/userdel.groovy
+++ b/Automation/idManagement/userdel.groovy
@@ -8,7 +8,7 @@
 //*                                                                                       *
 //*****************************************************************************************
 import com.ibm.dbb.build.*
-import org.apache.commons.cli.*
+import groovy.cli.commons.*
 
 // Take input
 def cli= new CliBuilder(usage: 'userdel [options] userid ')

--- a/Build/IDE/build/Tools.groovy
+++ b/Build/IDE/build/Tools.groovy
@@ -4,6 +4,7 @@ import com.ibm.dbb.build.html.*
 import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import java.io.*
+import groovy.cli.commons.*
 
 def parseArgs(String[] cliArgs) {
 	def cli = new CliBuilder(usage: 'build.groovy [options] buildfile')

--- a/Build/MortgageApplication/build/Tools.groovy
+++ b/Build/MortgageApplication/build/Tools.groovy
@@ -5,6 +5,7 @@ import com.ibm.dbb.build.html.*
 import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import groovy.transform.Field
+import groovy.cli.commons.*
 
 def parseArgs(String[] cliArgs, String usage) {
 	def cli = new CliBuilder(usage: usage)

--- a/Build/MortgageApplication/build/deploy.groovy
+++ b/Build/MortgageApplication/build/deploy.groovy
@@ -4,6 +4,8 @@ import com.ibm.dbb.build.report.*
 import com.ibm.dbb.build.report.records.*
 import groovy.time.*
 import groovy.xml.MarkupBuilder
+import groovy.cli.commons.*
+
 /**
  * This script creates a version in UrbanCode Deploy based on the build result. 
  *

--- a/Build/MortgageApplication/build/impacts.groovy
+++ b/Build/MortgageApplication/build/impacts.groovy
@@ -4,6 +4,7 @@ import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import java.nio.file.*
 import groovy.time.*
+import groovy.cli.commons.*
 
 /**
  * This script identifies which programs are impacted from source code changes since the last

--- a/Migration/jcl/groovy/JCLtoDBB.groovy
+++ b/Migration/jcl/groovy/JCLtoDBB.groovy
@@ -12,6 +12,7 @@ import groovy.util.*
 import groovy.transform.*
 import groovy.time.*
 import groovy.xml.*
+import groovy.cli.commons.*
 import java.nio.file.*
 import java.nio.file.attribute.*
 import com.ibm.dbb.*

--- a/Migration/sclm/groovy/GenerateBuildProperties.groovy
+++ b/Migration/sclm/groovy/GenerateBuildProperties.groovy
@@ -1,6 +1,7 @@
 import java.nio.file.*
 import com.ibm.dbb.*
 import groovy.transform.*
+import groovy.cli.commons.*
 
 //******************************************************************************
 //* Retrieves DBB environments

--- a/Migration/sclm/groovy/GenerateBuildScripts.groovy
+++ b/Migration/sclm/groovy/GenerateBuildScripts.groovy
@@ -1,6 +1,6 @@
 import java.nio.file.*
 import groovy.transform.*
-import groovy.util.CliBuilder
+import groovy.cli.commons.*
 import java.nio.file.attribute.*
 import com.ibm.dbb.*
 

--- a/Migration/sclm/groovy/GenerateDBBXml.groovy
+++ b/Migration/sclm/groovy/GenerateDBBXml.groovy
@@ -9,6 +9,7 @@
  */
 import groovy.xml.*
 import groovy.transform.*
+import groovy.cli.commons.*
 import java.nio.file.*
 import java.nio.file.attribute.*
 import com.ibm.dbb.*

--- a/Migration/sclm/groovy/GenerateZImport.groovy
+++ b/Migration/sclm/groovy/GenerateZImport.groovy
@@ -2,6 +2,7 @@ import com.ibm.dbb.*
 import java.nio.file.*
 import java.nio.file.attribute.*
 import groovy.transform.*
+import groovy.cli.commons.*
 import com.ibm.jzos.*
 
 /*******************************************************************************

--- a/Migration/sclm/groovy/SclmExtract.groovy
+++ b/Migration/sclm/groovy/SclmExtract.groovy
@@ -3,6 +3,7 @@ import com.ibm.dbb.build.*
 import com.ibm.jzos.*
 import java.nio.file.*
 import groovy.transform.SourceURI
+import groovy.cli.commons.*
 
 /*******************************************************************************
  *

--- a/Migration/sclm/templates/BUILD.template
+++ b/Migration/sclm/templates/BUILD.template
@@ -3,6 +3,7 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.repository.*
 import java.util.*
 import java.nio.file.*
+import groovy.cli.commons.*
 
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
 

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -3,6 +3,7 @@ import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.report.*
 import com.ibm.dbb.build.report.records.*
 import groovy.time.*
+import groovy.cli.commons.*
 import com.ibm.dbb.build.VersionInfo
 import groovy.xml.MarkupBuilder
 /**

--- a/Pipeline/DeployUCDComponentVersion/ucd-deploy.groovy
+++ b/Pipeline/DeployUCDComponentVersion/ucd-deploy.groovy
@@ -1,6 +1,7 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
 import groovy.transform.*
 import groovy.json.JsonSlurper
+import groovy.cli.commons.*
 
 import java.security.KeyManagementException
 import java.security.NoSuchAlgorithmException

--- a/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactoryHelpers.groovy
@@ -1,5 +1,6 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
 import groovy.transform.*
+import groovy.cli.commons.*
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -7,6 +7,7 @@ import com.ibm.dbb.build.DBBConstants.CopyMode
 import com.ibm.dbb.build.report.BuildReport
 import com.ibm.dbb.build.report.records.DefaultRecordFactory
 import groovy.transform.*
+import groovy.cli.commons.*
 
 /************************************************************************************
  * This script creates a simplified package with the outputs generated from a DBB build 

--- a/Pipeline/PublishSharedInterfaces/PublishPublicInterfaces.groovy
+++ b/Pipeline/PublishSharedInterfaces/PublishPublicInterfaces.groovy
@@ -4,6 +4,7 @@ import com.ibm.dbb.build.*
 import com.ibm.dbb.build.report.*
 import com.ibm.dbb.build.report.records.*
 import groovy.transform.*
+import groovy.cli.commons.*
 import java.nio.file.*;
 
 // PublishPublicInterfaces.groovy

--- a/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
+++ b/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
@@ -5,6 +5,7 @@ import com.ibm.dbb.build.*
 import com.ibm.dbb.build.report.*
 import com.ibm.dbb.build.report.records.*
 import groovy.transform.*
+import groovy.cli.commons.*
 import java.nio.file.PathMatcher
 import java.nio.file.FileSystems
 import java.nio.file.Path

--- a/Snippets/PropertyMappings/Mappings.groovy
+++ b/Snippets/PropertyMappings/Mappings.groovy
@@ -2,6 +2,7 @@
 import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
+import groovy.cli.commons.*
 
 
 def usage = "Mappings.groovy [options]"

--- a/Utilities/BuildReportPruner/argParser.groovy
+++ b/Utilities/BuildReportPruner/argParser.groovy
@@ -2,6 +2,7 @@ import com.ibm.dbb.build.*
 import com.ibm.dbb.build.report.*
 import com.ibm.dbb.repository.*
 import com.ibm.dbb.dependency.*
+import groovy.cli.commons.*
 
 user = "None"
 

--- a/Utilities/DeletePDS/DeletePDS.groovy
+++ b/Utilities/DeletePDS/DeletePDS.groovy
@@ -1,5 +1,6 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
 import groovy.transform.*
+import groovy.cli.commons.*
 import com.ibm.jzos.CatalogSearch;
 import com.ibm.jzos.CatalogSearchField;
 import com.ibm.jzos.ZFile;

--- a/Utilities/ReadSMFRecords/tools.groovy
+++ b/Utilities/ReadSMFRecords/tools.groovy
@@ -7,6 +7,8 @@ import com.ibm.dbb.build.*
 import com.ibm.dbb.build.internal.Messages
 import com.ibm.dbb.build.smf.*
 
+import groovy.cli.commons.*
+
 def parseArgs(String[] cliArgs){
 	def cli = new CliBuilder(usage: "readSMF.groovy [options]",header: "\nAvailable options\n")
 	cli.h(longOpt: 'help','help')

--- a/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
+++ b/Utilities/WebAppCleanUp/WebAppCleanUp.groovy
@@ -2,6 +2,7 @@
 import com.ibm.dbb.repository.*
 import com.ibm.dbb.build.*
 import groovy.transform.*
+import groovy.cli.commons.*
 
 // global variables
 @Field BuildProperties properties = BuildProperties.getInstance()


### PR DESCRIPTION
In previous versions of Groovy, CliBuilder was under the `groovy.util` package which is automatically imported. In Groovy 4.0.0, CliBuilder now resides under `groovy.commons.cli` and needs to be manually imported. This PR introduces changes to do so; however, the scripts will still run on Groovy 2.4.12 as groovy ignores non-existent splat import statements and will be able to find the class within `groovy.util`.

Changes Made:
- Added import statement for CliBuilder class from `groovy.commons.cli` to be compatible with Groovy 4.0.0 everywhere CliBuilder is implemented. 
- Updated various comments regarding a dependency on CliBuilder from Apache Commons Cli. After updating the imports, this dependency is no longer accurate.  