### PR TITLE
Enhance PackageBuildOutputs sample

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -136,8 +136,6 @@ else {
 
 	def String tarFileLabel = buildInfo[0].label
 	def String tarFileName = (props.tarFileName) ? props.tarFileName : "${buildInfo[0].label}.tar"
-	def String buildGroup = buildInfo[0].group
-
 
 	//Create a temporary directory on zFS to copy the load modules from data sets to
 	def tempLoadDir = new File("$props.workDir/tempPackageDir")

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -44,6 +44,10 @@ import groovy.cli.commons.*
  *                                                Artifactory details. (Optional)
  * -v,--versionName <versionName>                 Name of the Artifactory version.
  *                                                (Optional)
+ * -prop,--propertyFile <propertyFile>            ** Deprecated ** Absolute path of a
+ *                                                property file containing application
+ *                                                specific Artifactory details. (Optional)
+ *                                                
  * -h,--help                                      Prints this message
  *
  * Version 0 - 2019
@@ -322,7 +326,10 @@ def parseInput(String[] cliArgs){
 	// Artifactory Options:
 	cli.p(longOpt:'publish', 'Flag to indicate package upload to the provided Artifactory server. (Optional)')
 	cli.v(longOpt:'versionName', args:1, argName:'versionName', 'Name of the Artifactory version. (Optional)')
-	cli.artifactory(longOpt:'artifactoryPropertiesFile', args:1, argName:'artifactoryPropertiesFile', 'Absolute path of a property file containing application specific Artifactory details. (Optional)')
+	cli.artifactory(longOpt:'artifactoryPropertiesFile', args:1, argName:'artifactoryPropertiesFile', 'Path of a property file containing application specific Artifactory details. (Optional)')
+	// old prop option (deprecated)
+	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFile', 'Path of a property file containing application specific Artifactory details. (Optional) ** (Deprecated)')
+	
 	cli.verb(longOpt:'verbose', 'Flag to provide more log output. (Optional)')
 
 	cli.h(longOpt:'help', 'Prints this message')
@@ -339,6 +346,12 @@ def parseInput(String[] cliArgs){
 		def propertiesFile = new File(opts.properties)
 		if (propertiesFile.exists()){
 			propertiesFile.withInputStream { props.load(it) }
+		}
+	} else { // read default sample properties file shipped with the script
+		def scriptDir = new File(getClass().protectionDomain.codeSource.location.path).parent
+		def defaultPackagePropFile = new File("$scriptDir/packageBuildOutputs.properties")
+		if (defaultPackagePropFile.exists()){
+			defaultPackagePropFile.withInputStream { props.load(it) }
 		}
 	}
 	
@@ -357,6 +370,14 @@ def parseInput(String[] cliArgs){
 	// Optional artifactory properties
 	if (opts.artifactory){
 		def propertyFile = new File(opts.artifactory)
+		if (propertyFile.exists()){
+			propertyFile.withInputStream { props.load(it) }
+		}
+	}
+	
+	// ** Deprecated ** Read of artifactory properties
+	if (opts.prop){
+		def propertyFile = new File(opts.prop)
 		if (propertyFile.exists()){
 			propertyFile.withInputStream { props.load(it) }
 		}

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -68,7 +68,10 @@ props.startTime = startTime.format("yyyyMMdd.hhmmss.mmm")
 println("** PackageBuildOutputs start at $props.startTime")
 println("** Properties at startup:")
 props.each{k,v->
-	println "   $k -> $v"
+        if ( k == "artifactory.password" )
+            println "   $k -> xxxxxx "
+        else
+            println "   $k -> $v"
 }
 
 // Enable file tagging

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -53,6 +53,8 @@ groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/
 ### Package only including *.log files from build workspace
 
 ```
+groovyz dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /var/jenkins/workspace/MortgageApplication/BUILD-2 --packagingPropertiesFile dbb/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties --includeLogs *.log
+
 ** PackageBuildOutputs start at 20220222.112956.029
 ** Properties at startup:
    verbose -> false
@@ -60,26 +62,26 @@ groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/
    startTime -> 20220222.112956.029
    publish -> false
    includeLogs -> *.log
-   workDir -> /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2
-** Read build report data from /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/BuildReport.json
+   workDir -> /var/jenkins/workspace/MortgageApplication/BUILD-2
+** Read build report data from /var/jenkins/workspace/MortgageApplication/BUILD-2/BuildReport.json
 ** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
 ** Copying BuildOutputs to temporary package dir.
 *** Number of build outputs to publish: 8
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
-     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
-** Creating tar file at /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/MortgageApplication/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
+** Creating tar file at /var/jenkins/workspace/MortgageApplication/BUILD-2/build.20220222.021034.010.tar.
 
-** Adding BuildReport.json to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+** Adding BuildReport.json to /var/jenkins/workspace/MortgageApplication/BUILD-2/build.20220222.021034.010.tar.
 
-** Adding *.log to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+** Adding *.log to /var/jenkins/workspace/MortgageApplication/BUILD-2/build.20220222.021034.010.tar.
 
-** Package successfully created at /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+** Package successfully created at /var/jenkins/workspace/MortgageApplication/BUILD-2/build.20220222.021034.010.tar.
 ** Build finished
 ```
 

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -16,7 +16,7 @@ The ArtifactoryHelpers is a very simple implementation sufficient for a show cas
 
 1. After a successful DBB build, `PackageBuildOutputs.groovy` reads the build report and retrieves all outputs from the build report. It excludes outputs without a `deployType` as well as those labeled `ZUNIT-TESTCASE` 
 2. It then invokes CopyToHFS API to copy the outputs from the libraries to a temporary directory on zFS. It will set the file tags based on the ZLANG setting (Note: A workaround is implemented to tag files as binary); all files require to be tagged. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS.  
-3. It packages these load files into a tar file, and adds the BuildReport.json to it.
+3. It packages these load files into a tar file, and adds the BuildReport.json and optionally other build logs from the build workspace.
 4. (Optional) Publishes the tar file to the Artifactory repository based on the given configuration using the ArtifactoryHelpers.
 
 ## Invocation samples 
@@ -50,9 +50,43 @@ groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy --workDir /var/jenkins/
 ** Build finished
 ```
 
+### Package only including *.log files from build workspace
+
+```
+** PackageBuildOutputs start at 20220222.112956.029
+** Properties at startup:
+   verbose -> false
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD"]
+   startTime -> 20220222.112956.029
+   publish -> false
+   includeLogs -> *.log
+   workDir -> /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2
+** Read build report data from /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/BuildReport.json
+** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
+** Copying BuildOutputs to temporary package dir.
+*** Number of build outputs to publish: 8
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMORT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIS) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMPMT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCMORT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSCSMRD) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.LOAD(EPSMLIST) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.LOAD with DBB Copymode LOAD
+     Copying JENKINS.DBB.SAMP.BUILD.DBRM(EPSCMORT) to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/tempPackageDir/JENKINS.DBB.SAMP.BUILD.DBRM with DBB Copymode BINARY
+** Creating tar file at /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+
+** Adding BuildReport.json to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+
+** Adding *.log to /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+
+** Package successfully created at /var/jenkins/workspace/dbb-zappbuild-pipeline-artifactory-test/BUILD-2/build.20220222.021034.010.tar.
+** Build finished
+```
+
+
 ### Package and Publish to Artifactory
 ```
-groovyz /var/jenkins/pipeline/PublishLoadModule.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034 --propertyFile publish.properties -v MortgageRelease_1.0 -t myPackage.tar --verbose --publish
+groovyz /var/jenkins/pipeline/PublishLoadModule.groovy --workDir /var/jenkins/workspace/MortgageApplication/build.20210727.073406.034 --artifactoryPropertiesFile publish.properties -v MortgageRelease_1.0 -t myPackage.tar --verbose --publish
 
 
 ** PackageBuildOutputs start at 20210727.042032.020
@@ -108,32 +142,39 @@ groovyz  /var/jenkins/pipeline/ArtifactoryHelpers.groovy --url http://10.3.20.23
 ## Command Line Options Summary - PackageBuildOutputs
 
 ```
-usage: PackageBuildOutputs.groovy [options]
-
- -w,--workDir <dir>                    Absolute path to the DBB build
-                                       output directory
-
-Optional:
- -t,--tarFileName <filename>           Name of the package tar file.
-                                       (Optional)
- -d,--deployTypes <deployTypes>        Comma-seperated list of deployTypes
-                                       to filter on the scope of the tar
-                                       file. (Optional)
- -verb,--verbose                       Flag to provide more log output.
-                                       (Optional)
-                                       
-Artifactory Upload Options
-
- -p,--publish                          Flag to indicate package upload to
-                                       the provided Artifactory server.
-                                       (Optional)
- -prop,--propertyFile <propertyFile>   Absolute path of a property file
-                                       containing application specific
-                                       Artifactory details. (Optional)
- -v,--versionName <versionName>        Name of the Artifactory version.
-                                       (Optional)
-
- -h,--help                             Prints this message
+  usage: PackageBuildOutputs.groovy [options]
+ 
+  -w,--workDir <dir>                             Absolute path to the DBB build
+                                                 output directory
+  -properties,--packagingPropertiesFile <file>   Absolute path of a property file
+                                                 containing application specific
+                                                 packaging details. 
+                                                                                                                                          
+  Optional:
+  -t,--tarFileName <filename>                    Name of the package tar file.
+                                                 (Optional)
+  -d,--deployTypes <deployTypes>                 Comma-seperated list of deployTypes
+                                                 to filter on the scope of the tar
+                                                 file. (Optional)
+  -verb,--verbose                                Flag to provide more log output.
+                                                 (Optional)
+  -il,--includeLogs                              Comma-separated list of files/patterns
+                                                 from the USS build workspace                                               
+                                        
+  Optional Artifactory Upload opts:
+ 
+  -p,--publish                                   Flag to indicate package upload to
+                                                 the provided Artifactory server.
+                                                 (Optional)
+  -artifactory,
+    --artifactoryPropertiesFile <propertyFile>   Absolute path of a property file
+                                                 containing application specific
+                                                 Artifactory details. (Optional)
+  -v,--versionName <versionName>                 Name of the Artifactory version.
+                                                 (Optional)
+ 
+ 
+  -h,--help                                      Prints this message
 ```
 
 ## Command Line Options Summary - ArtifactoryHelpers

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -7,11 +7,15 @@
 #  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
 copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD"]
 
-# Comma-separated list of deployTypes to filter on the scope of the tar
-# file. (Optional)
-#  please not that the cli option `deployTypes` overwrites this setting 
-# deployTypes=
+# Comma-separated list of deployTypes to limit the scope of the tar
+# file to a subset of the build outputs. (Optional)
+#  Please not that the cli option `deployTypes` overwrites this setting
+#  Sample: deployTypesFilter=CICSLOAD,BATCHLOAD
+#
+# deployTypesFilter=
 
 # Comma-separated list of files/patterns from the USS build workspace. (Optional)
-#  please not that the cli option `includeLogs` overwrites this setting
+#  Please not that the cli option `includeLogs` overwrites this setting
+#  Sample: includeLogs = *.log,*.xml
+#
 # includeLogs = 

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -1,0 +1,17 @@
+########################################################################
+### The following properties are configure the packaging step
+########################################################################
+
+# required mapping of last level dataset qualifier to DBB CopyToFS CopyMode
+#  DBB supported copy modes are documented at
+#  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
+copyModeMap = ["COPYBOOK": CopyMode.TEXT, "COPY": CopyMode.TEXT, "DBRM": CopyMode.BINARY, "LOAD": CopyMode.LOAD]
+
+# Comma-separated list of deployTypes to filter on the scope of the tar
+# file. (Optional)
+#  please not that the cli option `deployTypes` overwrites this setting 
+# deployTypes=
+
+# Comma-separated list of files/patterns from the USS build workspace. (Optional)
+#  please not that the cli option `includeLogs` overwrites this setting
+# includeLogs = 

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -5,7 +5,7 @@
 # required mapping of last level dataset qualifier to DBB CopyToFS CopyMode
 #  DBB supported copy modes are documented at
 #  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
-copyModeMap = ["COPYBOOK": CopyMode.TEXT, "COPY": CopyMode.TEXT, "DBRM": CopyMode.BINARY, "LOAD": CopyMode.LOAD]
+copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD"]
 
 # Comma-separated list of deployTypes to filter on the scope of the tar
 # file. (Optional)


### PR DESCRIPTION
This is an enhancement  of the current version of the PackageBuildOutputs. The changes propose to

* Externalise the Map of last level qualifier to the DBB CopyMode into a property file.
* Allows to include additional build outputs from USS to the tar file via cli `--includeLogs` option or through the property `includeLogs` the property file (Comma-separated).
* Ability to configure the `deployTypeFilter` in the property file.
* lists the tar file contents when running in verbose mode

Please note, that the cli options have changed. `-prop/--propertyFile` for the Artifactory properties should be replaced with `-artifactory/--artifactoryPropertiesFile`. **Using `-prop/--propertyFile` is marked as deprecated** and might be removed in the next version. 