### PR TITLE
Enhanced dbb-ucd-packaging script to support package format v2 and process file deletions

### DIFF
--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -94,6 +94,12 @@ required options:
 
 optional cli options :
 
+ -bo,--buildReportOrder <arg>                   Build a cumulative package based on a comma separated list of
+                                                one or multiple DBB build reports processed in the provided order (Optional).
+
+ -boFile,--buildReportOrderFile <arg>           Build a cumulative package based on an input file that lists
+                                                one or multiple build reports defining the order of processing (Optional).
+
  buztool parameters : 
 
  -prop,--propertyFile <arg>                     Absolute path to UCD buztool property file. 
@@ -119,6 +125,7 @@ optional cli options :
  -prURL,--pullRequestURL <arg>                  URL to the Pull Request
 
  -g,--gitBranch <arg>                           Name of the git branch
+
 
  -p,--preview                                   Preview mode generate shiplist, but do
                                                 not run buztool.sh

--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -93,7 +93,7 @@ optional cli options :
                                                 the dbb-ucd-packaging script
 
  -rpFile,--repositoryInfoPropertiesFile <arg>   Absolute path to the property file containing
-                                                 URL prefixes to git provider (** Deprecated,
+                                                URL prefixes to git provider (** Deprecated,
                                                 please use cli option --packagingPropFiles **)
 
  -pURL,--pipelineURL <arg>                      URL to the pipeline build result

--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -3,32 +3,50 @@
 ## Summary
 
 An important step in the pipeline is to generate a deployable package. This sample groovy script
-- extracts information about the build outputs from the Dependency Based Build ```BuildReport.json```
+- extracts information about the build outputs from the Dependency Based Build ```BuildReport.json```. The script is able to take a single DBB Build report or multiple Build reports to build a cumulative package across multiple incremental builds. 
 - generates the UCD shiplist ```shiplist.xml``` file
 - invokes the ```buztool.sh``` with the approriate configuration to store the binary package in the artifact repository and to register a new UCD component version.
 
 ## High-level Processing flow
-Initialization
-- Read command line parameters
-- Read Application level properties are supposed to be passed via `--packagingPropFiles` (Optionally)
+**Initialization**
+- Read command line parameters. 
+- Read application and global properties which are supposed to be passed via `--packagingPropFiles` (Optionally)
 
-Process the DBB Build report
-- Read DBB's BuildReport.json from the pipeline work directory
+**Process the DBB Build report(s)**
+- Either reads DBB's BuildReport.json from the pipeline work directory or loops through the list of provided DBB Build reports (```--buildReportOrder``` or ```--buildReportOrderFile```).
 - Parse and extract build output information of records of type *ExecuteRecord* and *CopyToPDSRecord* (requires at least DBB 1.0.8)
-- Parse and extract the build output information for deleted build outputs of type *Delete_Record* written to the BuildReport by zAppBuild leveraging the AnyTypeRecord API which got introced with IBM Dependency Based Build 1.1.3.
+- Parse and extract the build output information for deleted build outputs of type *Delete_Record* written to the BuildReport by zAppBuild leveraging the AnyTypeRecord API which got introced with IBM Dependency Based Build 1.1.3. (requires at least DBB 1.1.3)
 
-Generates the UCD shiplist.xml file and invokes UCD packaging step
+**Generates the UCD shiplist.xml file and invokes UCD packaging step**
 - Write the shiplist.xml to the build directory
-    - Adds links back to the ci pipeline build to UCD component version (Optional).
-    - Adds UCD properties for bind information captured in the zAppBuild framework through generic PropertyRecords for DBRM members, such as bind_collectionID,bind_packageOwner,bind_qualifier on the element level - see [generateDb2BindInfoRecord configuration in zAppBuild](https://github.com/IBM/dbb-zappbuild/blob/06ff114ee22b4e41a09aa0640ac75b7e56c70521/build-conf/build.properties#L79-L89) (Optional).  
-    - Adds UCD properties to changes (git hashes) within the version control system (Optional).
-    - Adds source input information about the input files from the DBB Dependency Sets.
+    - Optionally, adds links back to the ci pipeline build, the git pull request to UCD component version.
+    - Adds UCD artifact level properties for bind information captured in the zAppBuild framework through generic PropertyRecords for DBRM members, such as bind_collectionID,bind_packageOwner,bind_qualifier on the element level - see [generateDb2BindInfoRecord configuration in zAppBuild](https://github.com/IBM/dbb-zappbuild/blob/06ff114ee22b4e41a09aa0640ac75b7e56c70521/build-conf/build.properties#L79-L89) (Optional).  
+    - Adds UCD artifact level properties to trace changes back to the version control system (via git hashes) (Optional).
+    - Adds source input information (and optionally links to the version control system) about the input files from the DBB Dependency Sets.
 - Invokes buztool.sh on USS with the generated shiplist file and passed cli options.
 ## Invocation samples
 
 Example invocation (default):
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion
+```
+
+Example to build a cumulative package across multiple build reports via `buildReportOrder`: 
+
+```
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --buildReportOrder /u/ibmuser/sample_buildreports/BuildReport_1.json,/u/ibmuser/sample_buildreports/BuildReport_2.json,/u/ibmuser/sample_buildreports/BuildReport_3.json --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion
+```
+
+Example to build a cumulative package across multiple build reports via `buildReportOrderFile`. The file contains the references to the locations of the buildReport: 
+
+```
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --buildReportOrderFile /u/ibmuser/sample_buildreports/BuildReportOrderFile.txt --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion
+```
+/u/ibmuser/sample_buildreports/BuildReportOrderFile.txt
+```
+/u/ibmuser/sample_buildreports/BuildReport_1.json
+/u/ibmuser/sample_buildreports/BuildReport_2.json
+/u/ibmuser/sample_buildreports/BuildReport_3.json 
 ```
 
 Example to leverage [UCD packaging format v2](https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format): 
@@ -36,25 +54,25 @@ Example to leverage [UCD packaging format v2](https://www.ibm.com/docs/en/urbanc
 * Please note that this requires to define the mapping of the copyModes through the buztool properties file.
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --ucdV2PackageFormat
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --ucdV2PackageFormat
 ```
 
 Example to establish link to the pipeline url: 
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/
 ```
 
-Example to establish link to the pipeline url and links for each deployable artifact to the git provider: 
+Example to establish link to the pipeline url and links for each deployable artifact to the git provider (see sample applicationRepositoryProps.properties): 
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --packagingPropFiles /var/dbb/extensions/ucd-packaging/mortgageRepositoryProps.properties 
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --packagingPropFiles /var/dbb/extensions/ucd-packaging/mortgageRepositoryProps.properties 
 ```
 
-Example to establish link to the pipeline url and git branch: 
+Example to establish links to the pipeline url, the git branch and the pull request in the UCD component version: 
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --gitBranch development
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --propertyFile /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --pullRequestURL https://github.com/IBM/dbb/pull/102 --gitBranch development
 ```
 
 
@@ -98,6 +116,8 @@ optional cli options :
 
  -pURL,--pipelineURL <arg>                      URL to the pipeline build result
 
+ -prURL,--pullRequestURL <arg>                  URL to the Pull Request
+
  -g,--gitBranch <arg>                           Name of the git branch
 
  -p,--preview                                   Preview mode generate shiplist, but do
@@ -110,144 +130,99 @@ utility options :
  ```
 
 
- ## Sample script log
+ ## Sample console log for processing a single BuildReport.json
 A sample invocation which stores the application package in an external artifact repository in UCD packaging format v2, including all traceability links.
 
+```
+/var/jenkins/workspace/zunit-retirementCalculator/dbb/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /var/jenkins/workspace/zunit-retirementCalculator/BUILD-135/build.20220531.013558.035 --component retirementCalculatorGithub --prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties --versionName 135_20220531.113630.036 --packagingPropFiles /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalulcatur.packaging.properties --ucdV2PackageFormat --pipelineURL http://jenkins-server/job/zunit-retirementCalculator/135/ --gitBranch main
+```
+
 <details>
-  <summary>Console outputs</summary>
+  <summary>Console log</summary>
 
 
 **dbb-ucd-packaging script output**
 
 ```
-+ /usr/lpp/dbb/v1r0/bin/groovyz /var/jenkins/workspace/zunit-retirementCalculator/dbb/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002 --component retirementCalculator --prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties --versionName 112_20220315.050325.003 --packagingPropFiles /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalulcatur.packaging.properties --ucdV2PackageFormat --pipelineURL http://jenkins-server/job/zunit-retirementCalculator/112/ --gitBranch main 
-** Create version start at 20220315.080327.003
+** Create version start at 20220531.013637.036
 ** Properties at startup:
-   workDir -> /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002
-   startTime -> 20220315.080327.003
-   versionName -> 112_20220315.050325.003
-   git_commitURL_prefix -> https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit
-   git_treeURL_prefix -> https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree
+   buztoolPropertyFile -> /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties
+   workDir -> /var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035
+   startTime -> 20220531.013637.036
+   versionName -> 120_20220531.113630.036
+   git_commitURL_prefix -> https://github.ibm.com/zDevOps/retirementCalculator/commit
+   git_treeURL_prefix -> https://github.ibm.com/zDevOps/retirementCalculator/tree
+   ucdV2PackageFormat -> true
+   preview -> true
+   gitBranch -> main
+   containerMapping -> ["LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT"]
+   buildReportOrder -> [/var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035/BuildReport.json]
+   pipelineURL -> http://jenkins-server/job/zunit-retirementCalculator/120/
+   buztoolPath -> /var/ucd-agent/bin/buztool.sh
+   component -> retirementCalculatorGithub
+* Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 1.1.3.
+**  Reading provided build report(s).
+*** Parsing DBB build report /var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035/BuildReport.json.
+**  Deployable files detected in /var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035/BuildReport.json
+   JENKINS.ZDAT.RETIRE.LOAD(EBUD01), LOAD
+** Generate UCD ship list file
+   Creating general UCD component version properties.
+   Storing DBB Build result properties as general component version properties due to single build report.
+   Creating shiplist record for build output JENKINS.ZDAT.RETIRE.LOAD(EBUD01) with recordType EXECUTE.
+** Write ship list file to  /var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035/shiplist.xml
+** Following UCD buztool cmd will be invoked
+/var/ucd-agent/bin/buztool.sh createzosversion2 -c retirementCalculatorGithub -s /var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035/shiplist.xml -o /var/jenkins/workspace/zunit-retirementCalculator/BUILD-120/build.20220531.013558.035/buztool.output -prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties -v "120_20220531.113630.036" 
+
+```
+</details>
+
+ ## Sample console log for processing multiple BuildReports to assemble a cumulative package.
+
+A sample invocation which builds a cumulative package across multiple build reports leveraging the `--buildReportOrder` cli option:
+
+```
+groovyz /var/jenkins/workspace/zunit-retirementCalculator/dbb/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /var/jenkins/workspace/zunit-retirementCalculator/BUILD-135/build.20220531.013558.035 --buildReportOrder /var/jenkins/tmp/BuildReport-134.json,/var/jenkins/tmp/BuildReport-135.json --component retirementCalculatorGithub --prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties --versionName 135_20220531.113630.036 --packagingPropFiles /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalulcatur.packaging.properties --ucdV2PackageFormat --pipelineURL http://jenkins-server/job/zunit-retirementCalculator/135/ --gitBranch main
+```
+
+<details>
+  <summary>Console log</summary>
+
+
+**dbb-ucd-packaging script output**
+
+```
+** Create version start at 20220531.013644.036
+** Properties at startup:
+   buztoolPropertyFile -> /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties
+   workDir -> /var/jenkins/workspace/zunit-retirementCalculator/BUILD-135/build.20220531.013558.035
+   startTime -> 20220531.013644.036
+   versionName -> 135_20220531.113630.036
+   git_commitURL_prefix -> https://github.ibm.com/zDevOps/retirementCalculator/commit
+   git_treeURL_prefix -> https://github.ibm.com/zDevOps/retirementCalculator/tree
    ucdV2PackageFormat -> true
    preview -> false
    gitBranch -> main
    containerMapping -> ["LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT"]
-   pipelineURL -> http://jenkins-server/job/zunit-retirementCalculator/112/
+   buildReportOrder -> [/var/jenkins/tmp/BuildReport-134.json, /var/jenkins/tmp/BuildReport-135.json]
+   pipelineURL -> http://jenkins-server/job/zunit-retirementCalculator/135/
    buztoolPath -> /var/ucd-agent/bin/buztool.sh
-   propertyFileSettings -> /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties
-   component -> retirementCalculator
-** Read build report data from /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/BuildReport.json
-** Find deployable outputs in the build report 
-   * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 1.1.2.
-** Deployable files
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD01), LOAD
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD03), LOAD
+   component -> retirementCalculatorGithub
+* Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 1.1.3.
+**  Reading provided build report(s).
+*** Parsing DBB build report /var/jenkins/tmp/BuildReport-134.json.
+
+**  Deployable files detected in /var/jenkins/tmp/BuildReport-134.json
    JENKINS.ZDAT.RETIRE.LOAD(EBUD0RUN), LOAD
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD02), LOAD
-** Deleted files
+*** Parsing DBB build report /var/jenkins/tmp/BuildReport-135.json.
+**  Deployable files detected in /var/jenkins/tmp/BuildReport-135.json
+   JENKINS.ZDAT.RETIRE.LOAD(EBUD01), LOAD
 ** Generate UCD ship list file
-** Write ship list file to  /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml
+   Creating general UCD component version properties.
+   Creating shiplist record for build output JENKINS.ZDAT.RETIRE.LOAD(EBUD0RUN) with recordType EXECUTE.
+   Creating shiplist record for build output JENKINS.ZDAT.RETIRE.LOAD(EBUD01) with recordType EXECUTE.
+** Write ship list file to  /var/jenkins/workspace/zunit-retirementCalculator/BUILD-135/build.20220531.013558.035/shiplist.xml
 ** Following UCD buztool cmd will be invoked
-/var/ucd-agent/bin/buztool.sh createzosversion2 -c retirementCalculator -s /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml -o /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/buztool.output -prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties -v 112_20220315.050325.003 
-** Create version by running UCD buztool
-zOS toolkit config   : /var/ucd-agent/ (7.2.1.0,20211011-0758)
-zOS toolkit binary   : /var/ucd-agent/ (7.2.1.0,20211011-0758)
-zOS toolkit data set : RATCFG.UCD.V7R2M1 (7.2.1.0,20211011-0758)
-Reading parameters:
-....Command : createzosversion2
-....Component : retirementCalculator
-....Version : 112_20220315.050325.003
-....Shiplist file : /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml
-....Buztool Properties File : /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties
-....Output File:/var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/buztool.output
-Verifying version
-....Repository location : /var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003
-Pre-processing shiplist:
-....Shiplist after processing :/var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003/shiplist.xml
-Packaging data sets:
-....Shiplist : /var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003/shiplist.xml
-....Location to store zip :  /var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003
-....Zip name : package.zip
-....verbose : false
-....Datasets copied succesfully
-Post-processing package:
-PackageManifest file post-processing completed. 
-Create version and store package:
-....Uploading to artifactory using details from prop file
-....Executing request PUT http://artifactory-server/artifactory/RetirementCalculator/112_20220315.050325.003.zip HTTP/1.1
-....Version artifacts stored to ARTIFACTORY server
-....Version created in UCD server
-....Version:112_20220315.050325.003 created
-Elapsed time: 2.0 seconds.
-
-** buztool output properties
-   version.url -> https://ucd.dat.ibm.com:8443//#version/c9f2f810-8314-4baa-af79-937a57f81c51
-   version.repository.type -> CODESTATION
-   version.name -> 112_20220315.050325.003
-   version.id -> c9f2f810-8314-4baa-af79-937a57f81c51
-   component.name -> retirementCalculator
-   version.shiplist -> /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml
-** Build finished
-```
-
-**Generated Shiplistfile.xml**
-
-```
-<?xml version="1.0" encoding="CP037"?>
-<manifest type='MANIFEST_SHIPLIST'>
-  <property name='dbb-buildResultUrl' value='https://10.3.20.96:10443/dbb/rest/buildResult/90543' />
-  <property name='ci-pipelineUrl' value='http://jenkins-server/job/zunit-retirementCalculator/112/' />
-  <property name='ci-gitBranch' value='main' />
-  <property name='filesProcessed' value='8' />
-  <property name=':githash:retirementCalculator' value='532647316aecd2acd4b3a545e8985080c97415db' />
-  <property name='fullBuild' value='true' />
-  <property name=':giturl:retirementCalculator' value='git@github.ibm.com:zDevOps-Acceleration/retirementCalculator.git' />
-  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
-    <resource name='EBUD01' type='PDSMember' deployType='LOAD'>
-      <property name='buildcommand' value='IEWBLINK' />
-      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
-      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
-      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
-      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD01.cbl'>
-        <input name='retirementCalculator/cobol/EBUD01.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD01.cbl' />
-      </inputs>
-    </resource>
-  </container>
-  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
-    <resource name='EBUD03' type='PDSMember' deployType='LOAD'>
-      <property name='buildcommand' value='IEWBLINK' />
-      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
-      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
-      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
-      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD03.cbl'>
-        <input name='retirementCalculator/cobol/EBUD03.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD03.cbl' />
-      </inputs>
-    </resource>
-  </container>
-  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
-    <resource name='EBUD0RUN' type='PDSMember' deployType='LOAD'>
-      <property name='buildcommand' value='IEWBLINK' />
-      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
-      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
-      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
-      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD0RUN.cbl'>
-        <input name='retirementCalculator/cobol/EBUD0RUN.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD0RUN.cbl' />
-        <input name='retirementCalculator/copy/LINPUT.cpy' compileType='COPY' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/copy/LINPUT.cpy' />
-      </inputs>
-    </resource>
-  </container>
-  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
-    <resource name='EBUD02' type='PDSMember' deployType='LOAD'>
-      <property name='buildcommand' value='IEWBLINK' />
-      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
-      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
-      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
-      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD02.cbl'>
-        <input name='retirementCalculator/cobol/EBUD02.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD02.cbl' />
-      </inputs>
-    </resource>
-  </container>
-</manifest>
+/var/ucd-agent/bin/buztool.sh createzosversion2 -c retirementCalculatorGithub -s /var/jenkins/workspace/zunit-retirementCalculator/BUILD-135/build.20220531.013558.035/shiplist.xml -o /var/jenkins/workspace/zunit-retirementCalculator/BUILD-135/build.20220531.013558.035/buztool.output -prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties -v "135_20220531.113630.036" 
 ```
 </details>
  

--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -1,42 +1,63 @@
 # IBM UCD Packaging based on IBM DBB Build Report
 
+## Summary
+
 An important step in the pipeline is to generate a deployable package. This sample groovy script
-- extracts information about the build outputs from the DBB BuildReport.json
+- extracts information about the build outputs from the Dependency Based Build ```BuildReport.json```
 - generates the UCD shiplist ```shiplist.xml``` file
-- invokes the ```buztool.sh``` of UCD
+- invokes the ```buztool.sh``` with the approriate configuration to store the binary package in the artifact repository and to register a new UCD component version.
+
+## High-level Processing flow
+Initialization
+- Read command line parameters
+- Read Application level properties are supposed to be passed via `--packagingPropFiles` (Optionally)
+
+Process the DBB Build report
+- Read DBB's BuildReport.json from the pipeline work directory
+- Parse and extract build output information of records of type *ExecuteRecord* and *CopyToPDSRecord* (requires at least DBB 1.0.8)
+- Parse and extract the build output information for deleted build outputs of type *Delete_Record* written to the BuildReport by zAppBuild leveraging the AnyTypeRecord API which got introced with IBM Dependency Based Build 1.1.3.
+
+Generates the UCD shiplist.xml file and invokes UCD packaging step
+- Write the shiplist.xml to the build directory
+	- Adds links back to the ci pipeline build to UCD component version (Optional).
+	- Adds UCD properties for bind information captured in the zAppBuild framework through generic PropertyRecords for DBRM members, such as bind_collectionID,bind_packageOwner,bind_qualifier on the element level - see [generateDb2BindInfoRecord configuration in zAppBuild](https://github.com/IBM/dbb-zappbuild/blob/06ff114ee22b4e41a09aa0640ac75b7e56c70521/build-conf/build.properties#L79-L89) (Optional).  
+	- Adds UCD properties to changes (git hashes) within the version control system (Optional).
+	- Adds source input information about the input files from the DBB Dependency Sets.
+- Invokes buztool.sh on USS with the generated shiplist file and passed cli options.
+## Invocation samples
 
 Example invocation (default):
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/artifactory.properties --versionName MyVersion
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion
+```
+
+Example to leverage [UCD packaging format v2](https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format): 
+
+* Please note that this requires to define the mapping of the copyModes through the buztool properties file.
+
+```
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --ucdV2PackageFormat
 ```
 
 Example to establish link to the pipeline url: 
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/
 ```
 
 Example to establish link to the pipeline url and links for each deployable artifact to the git provider: 
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --repositoryInfoPropertiesFile /var/dbb/extensions/ucd-packaging/mortgageRepositoryProps.properties 
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --packagingPropFiles /var/dbb/extensions/ucd-packaging/mortgageRepositoryProps.properties 
 ```
 
 Example to establish link to the pipeline url and git branch: 
 
 ```
-$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --gitBranch development
+$DBB_HOME/bin/groovyz dbb-ucd-packaging.groovy --buztool /var/ucd/agent/bin/buztool.sh --workDir /var/build/job/dbb-outputdir --component MYCOMP --prop /var/ucd/agent/conf/artifactrepository/myapp.artifactory.properties --versionName MyVersion --pipelineURL https://ci-server/job/MortgageApplication/34/ --gitBranch development
 ```
 
-## Processing flow
-- Read command line parameters
-- Read DBB's BuildReport.json from the pipeline work directory
-- Parse and extract build output information of records of type *ExecuteRecord* and *CopyToPDSRecord*
-- Optionally adds generic PropertyRecords, which are linked to the buildfile
-- Optionally adds links back to the ci pipeline build 
-- Optionally adds links to changes (git hashes) within the version control system
-- Generates shiplist.xml file
-- Invokes buztool.sh on USS with the generated options
+
 
 ## Command Line Options Summary
 ```
@@ -44,26 +65,189 @@ $DBB_HOME/bin/groovyz <ussLocation>/dbb-ucd-packaging.groovy [options]
 
 required options:
 
- -b,--buztool <file>               		Absolute path to UrbanCode Deploy
-                                    		buztool.sh script
- -c,--component <name>              		Name of the UCD component to
-                                    		create version in
- -w,--workDir <dir>                 		Absolute path to the DBB build
-                                    		output directory
+ -b,--buztool <file>           		    		Absolute path to UrbanCode Deploy
+                                    			buztool.sh script
 
-optional options:
- -ar,--artifactRepository <arg>     		Absolute path to Artifact Respository Server
-                                    		Server connection file
- -prop,--propertyFile <arg>         		Absolute path to property file. 
-                                    		From UCD v7.1.x and greater it replace the -ar option.
- -v,--versionName <arg>             		Name of the UCD component version
- -pURL,--pipelineURL <arg>			URL to the pipeline build result
- -g,--gitBranch <arg>					Name of the git branch
- -rpFile,--repositoryInfoPropertiesFile <arg>	Absolute path to the property file containing URL prefixes to git provider
- -p,--preview                       		Preview mode generate shiplist, but do
-                                    		not run buztool.sh
+ -c,--component <name>              			Name of the UCD component to
+                                    			create version in
+
+ -w,--workDir <dir>                 			Absolute path to the DBB build
+												output directory
+
+optional cli options :
+
+ buztool parameters : 
+
+ -prop,--propertyFile <arg>         			Absolute path to UCD buztool property file. 
+                                    			From UCD v7.1.x and greater it replaces the -ar option.
+
+ -ar,--artifactRepository <arg>     			Absolute path to Artifact Respository Server
+                                    			Server connection file (** Deprecated, 
+												Please use --propertyFile instead **)
+
+ -v,--versionName <arg>             			Name of the UCD component version
+ 
+ packaging script parameters : 
+
+ -ppf,--packagingPropFiles <arg>				Comma separated list of property files to configure
+												the dbb-ucd-packaging script
+
+ -rpFile,--repositoryInfoPropertiesFile <arg>	Absolute path to the property file containing
+ 												URL prefixes to git provider (** Deprecated,
+                                                please use cli option --packagingPropFiles **)
+
+ -pURL,--pipelineURL <arg>	     				URL to the pipeline build result
+
+ -g,--gitBranch <arg>							Name of the git branch
+
+ -p,--preview                       			Preview mode generate shiplist, but do
+ 						               			not run buztool.sh
 
 
-utility options
- -help,--help             Prints this message
+utility options :
+
+ -help,--help             						Prints this message
  ```
+
+
+ ## Sample script log
+A sample invocation which stores the application package in an external artifact repository in UCD packaging format v2, including all traceability links.
+
+<details>
+  <summary>Console outputs</summary>
+
+
+**dbb-ucd-packaging script output**
+
+```
++ /usr/lpp/dbb/v1r0/bin/groovyz /var/jenkins/workspace/zunit-retirementCalculator/dbb/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002 --component retirementCalculator --prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties --versionName 112_20220315.050325.003 --packagingPropFiles /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalulcatur.packaging.properties --ucdV2PackageFormat --pipelineURL http://jenkins-server/job/zunit-retirementCalculator/112/ --gitBranch main 
+** Create version start at 20220315.080327.003
+** Properties at startup:
+   workDir -> /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002
+   startTime -> 20220315.080327.003
+   versionName -> 112_20220315.050325.003
+   git_commitURL_prefix -> https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit
+   git_treeURL_prefix -> https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree
+   ucdV2PackageFormat -> true
+   preview -> false
+   gitBranch -> main
+   containerMapping -> ["LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT"]
+   pipelineURL -> http://jenkins-server/job/zunit-retirementCalculator/112/
+   buztoolPath -> /var/ucd-agent/bin/buztool.sh
+   propertyFileSettings -> /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties
+   component -> retirementCalculator
+** Read build report data from /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/BuildReport.json
+** Find deployable outputs in the build report 
+   * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 1.1.2.
+** Deployable files
+   JENKINS.ZDAT.RETIRE.LOAD(EBUD01), LOAD
+   JENKINS.ZDAT.RETIRE.LOAD(EBUD03), LOAD
+   JENKINS.ZDAT.RETIRE.LOAD(EBUD0RUN), LOAD
+   JENKINS.ZDAT.RETIRE.LOAD(EBUD02), LOAD
+** Deleted files
+** Generate UCD ship list file
+** Write ship list file to  /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml
+** Following UCD buztool cmd will be invoked
+/var/ucd-agent/bin/buztool.sh createzosversion2 -c retirementCalculator -s /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml -o /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/buztool.output -prop /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties -v 112_20220315.050325.003 
+** Create version by running UCD buztool
+zOS toolkit config   : /var/ucd-agent/ (7.2.1.0,20211011-0758)
+zOS toolkit binary   : /var/ucd-agent/ (7.2.1.0,20211011-0758)
+zOS toolkit data set : RATCFG.UCD.V7R2M1 (7.2.1.0,20211011-0758)
+Reading parameters:
+....Command : createzosversion2
+....Component : retirementCalculator
+....Version : 112_20220315.050325.003
+....Shiplist file : /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml
+....Buztool Properties File : /var/jenkins/workspace/zunit-retirementCalculator//retirementCalculator/retirementCalculator/application-conf/retirementCalculator.ucd.properties
+....Output File:/var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/buztool.output
+Verifying version
+....Repository location : /var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003
+Pre-processing shiplist:
+....Shiplist after processing :/var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003/shiplist.xml
+Packaging data sets:
+....Shiplist : /var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003/shiplist.xml
+....Location to store zip :  /var/ucd-agent/var/repository/retirementCalculator/112_20220315.050325.003
+....Zip name : package.zip
+....verbose : false
+....Datasets copied succesfully
+Post-processing package:
+PackageManifest file post-processing completed. 
+Create version and store package:
+....Uploading to artifactory using details from prop file
+....Executing request PUT http://artifactory-server/artifactory/RetirementCalculator/112_20220315.050325.003.zip HTTP/1.1
+....Version artifacts stored to ARTIFACTORY server
+....Version created in UCD server
+....Version:112_20220315.050325.003 created
+Elapsed time: 2.0 seconds.
+
+** buztool output properties
+   version.url -> https://ucd.dat.ibm.com:8443//#version/c9f2f810-8314-4baa-af79-937a57f81c51
+   version.repository.type -> CODESTATION
+   version.name -> 112_20220315.050325.003
+   version.id -> c9f2f810-8314-4baa-af79-937a57f81c51
+   component.name -> retirementCalculator
+   version.shiplist -> /var/jenkins/workspace/zunit-retirementCalculator/BUILD-112/build.20220315.080246.002/shiplist.xml
+** Build finished
+```
+
+**Generated Shiplistfile.xml**
+
+```
+<?xml version="1.0" encoding="CP037"?>
+<manifest type='MANIFEST_SHIPLIST'>
+  <property name='dbb-buildResultUrl' value='https://10.3.20.96:10443/dbb/rest/buildResult/90543' />
+  <property name='ci-pipelineUrl' value='http://jenkins-server/job/zunit-retirementCalculator/112/' />
+  <property name='ci-gitBranch' value='main' />
+  <property name='filesProcessed' value='8' />
+  <property name=':githash:retirementCalculator' value='532647316aecd2acd4b3a545e8985080c97415db' />
+  <property name='fullBuild' value='true' />
+  <property name=':giturl:retirementCalculator' value='git@github.ibm.com:zDevOps-Acceleration/retirementCalculator.git' />
+  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
+    <resource name='EBUD01' type='PDSMember' deployType='LOAD'>
+      <property name='buildcommand' value='IEWBLINK' />
+      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
+      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
+      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
+      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD01.cbl'>
+        <input name='retirementCalculator/cobol/EBUD01.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD01.cbl' />
+      </inputs>
+    </resource>
+  </container>
+  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
+    <resource name='EBUD03' type='PDSMember' deployType='LOAD'>
+      <property name='buildcommand' value='IEWBLINK' />
+      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
+      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
+      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
+      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD03.cbl'>
+        <input name='retirementCalculator/cobol/EBUD03.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD03.cbl' />
+      </inputs>
+    </resource>
+  </container>
+  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
+    <resource name='EBUD0RUN' type='PDSMember' deployType='LOAD'>
+      <property name='buildcommand' value='IEWBLINK' />
+      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
+      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
+      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
+      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD0RUN.cbl'>
+        <input name='retirementCalculator/cobol/EBUD0RUN.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD0RUN.cbl' />
+        <input name='retirementCalculator/copy/LINPUT.cpy' compileType='COPY' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/copy/LINPUT.cpy' />
+      </inputs>
+    </resource>
+  </container>
+  <container name='JENKINS.ZDAT.RETIRE.LOAD' type='PDS' deployType='LOAD'>
+    <resource name='EBUD02' type='PDSMember' deployType='LOAD'>
+      <property name='buildcommand' value='IEWBLINK' />
+      <property name='buildoptions' value='RENT,REUS=RENT,LIST,XREF,AMODE=31,RMODE=ANY' />
+      <property name='githash' value='532647316aecd2acd4b3a545e8985080c97415db' />
+      <property name='git-link-to-commit' value='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/commit/532647316aecd2acd4b3a545e8985080c97415db' />
+      <inputs url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD02.cbl'>
+        <input name='retirementCalculator/cobol/EBUD02.cbl' compileType='Main' url='https://github.ibm.com/zDevOps-Acceleration/retirementCalculator/tree/532647316aecd2acd4b3a545e8985080c97415db/retirementCalculator/cobol/EBUD02.cbl' />
+      </inputs>
+    </resource>
+  </container>
+</manifest>
+```
+</details>
+ 

--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -19,10 +19,10 @@ Process the DBB Build report
 
 Generates the UCD shiplist.xml file and invokes UCD packaging step
 - Write the shiplist.xml to the build directory
-	- Adds links back to the ci pipeline build to UCD component version (Optional).
-	- Adds UCD properties for bind information captured in the zAppBuild framework through generic PropertyRecords for DBRM members, such as bind_collectionID,bind_packageOwner,bind_qualifier on the element level - see [generateDb2BindInfoRecord configuration in zAppBuild](https://github.com/IBM/dbb-zappbuild/blob/06ff114ee22b4e41a09aa0640ac75b7e56c70521/build-conf/build.properties#L79-L89) (Optional).  
-	- Adds UCD properties to changes (git hashes) within the version control system (Optional).
-	- Adds source input information about the input files from the DBB Dependency Sets.
+    - Adds links back to the ci pipeline build to UCD component version (Optional).
+    - Adds UCD properties for bind information captured in the zAppBuild framework through generic PropertyRecords for DBRM members, such as bind_collectionID,bind_packageOwner,bind_qualifier on the element level - see [generateDb2BindInfoRecord configuration in zAppBuild](https://github.com/IBM/dbb-zappbuild/blob/06ff114ee22b4e41a09aa0640ac75b7e56c70521/build-conf/build.properties#L79-L89) (Optional).  
+    - Adds UCD properties to changes (git hashes) within the version control system (Optional).
+    - Adds source input information about the input files from the DBB Dependency Sets.
 - Invokes buztool.sh on USS with the generated shiplist file and passed cli options.
 ## Invocation samples
 
@@ -65,48 +65,48 @@ $DBB_HOME/bin/groovyz <ussLocation>/dbb-ucd-packaging.groovy [options]
 
 required options:
 
- -b,--buztool <file>           		    		Absolute path to UrbanCode Deploy
-                                    			buztool.sh script
+ -b,--buztool <file>                            Absolute path to UrbanCode Deploy
+                                                buztool.sh script
 
- -c,--component <name>              			Name of the UCD component to
-                                    			create version in
+ -c,--component <name>                          Name of the UCD component to
+                                                create version in
 
- -w,--workDir <dir>                 			Absolute path to the DBB build
-												output directory
+ -w,--workDir <dir>                             Absolute path to the DBB build
+                                                output directory
 
 optional cli options :
 
  buztool parameters : 
 
- -prop,--propertyFile <arg>         			Absolute path to UCD buztool property file. 
-                                    			From UCD v7.1.x and greater it replaces the -ar option.
+ -prop,--propertyFile <arg>                     Absolute path to UCD buztool property file. 
+                                                From UCD v7.1.x and greater it replaces the -ar option.
 
- -ar,--artifactRepository <arg>     			Absolute path to Artifact Respository Server
-                                    			Server connection file (** Deprecated, 
-												Please use --propertyFile instead **)
+ -ar,--artifactRepository <arg>                 Absolute path to Artifact Respository Server
+                                                Server connection file (** Deprecated, 
+                                                Please use --propertyFile instead **)
 
- -v,--versionName <arg>             			Name of the UCD component version
+ -v,--versionName <arg>                         Name of the UCD component version
  
  packaging script parameters : 
 
- -ppf,--packagingPropFiles <arg>				Comma separated list of property files to configure
-												the dbb-ucd-packaging script
+ -ppf,--packagingPropFiles <arg>                Comma separated list of property files to configure
+                                                the dbb-ucd-packaging script
 
- -rpFile,--repositoryInfoPropertiesFile <arg>	Absolute path to the property file containing
- 												URL prefixes to git provider (** Deprecated,
+ -rpFile,--repositoryInfoPropertiesFile <arg>   Absolute path to the property file containing
+                                                 URL prefixes to git provider (** Deprecated,
                                                 please use cli option --packagingPropFiles **)
 
- -pURL,--pipelineURL <arg>	     				URL to the pipeline build result
+ -pURL,--pipelineURL <arg>                      URL to the pipeline build result
 
- -g,--gitBranch <arg>							Name of the git branch
+ -g,--gitBranch <arg>                           Name of the git branch
 
- -p,--preview                       			Preview mode generate shiplist, but do
- 						               			not run buztool.sh
+ -p,--preview                                   Preview mode generate shiplist, but do
+                                                not run buztool.sh
 
 
 utility options :
 
- -help,--help             						Prints this message
+ -help,--help                                   Prints this message
  ```
 
 

--- a/Pipeline/CreateUCDComponentVersion/applicationRepositoryProps.properties
+++ b/Pipeline/CreateUCDComponentVersion/applicationRepositoryProps.properties
@@ -1,3 +1,7 @@
+########################################
+# Traceability configuration
+########################################
+
 # git URL to create a link in the component version to the commit  
 # depends on Git provider and application repository
 # sample gitlab: https://gitlab.dat.ibm.com/ibm/zappbuild/-/tree
@@ -9,3 +13,18 @@
 # sample gitlab: https://gitlab.dat.ibm.com/dat/genapp/-/tree
 # sample github: https://github.com/ibm/dbb-zappbuild/tree
 #git_treeURL_prefix=http://gitlab.dat.ibm.com/dat/genapp/-/tree
+
+########################################
+# UCD packaging format v2 configuration
+########################################
+
+# containerMapping is defining the appropriate deployType
+#  for the container shiplist entry to support UCD package format v2
+#
+# this maps the *last level qualifiers* to the defined *deployType*, which is 
+#  configured in the buztool properties file 
+# 
+# For the required modifications of the buztool properties file see
+#  https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format
+#
+containerMapping = ["LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT]

--- a/Pipeline/CreateUCDComponentVersion/applicationRepositoryProps.properties
+++ b/Pipeline/CreateUCDComponentVersion/applicationRepositoryProps.properties
@@ -27,4 +27,4 @@
 # For the required modifications of the buztool properties file see
 #  https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format
 #
-containerMapping = ["LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT]
+containerMapping = ["LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT"]

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -340,7 +340,7 @@ def parseInput(String[] cliArgs){
 	cli.ar(longOpt:'artifactRepository', args:1, argName:'artifactRepositorySettings', 'Absolute path to Artifactory Server connection file')
 	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFileSettings', 'Absolute path to property file (Optional). From UCD v7.1.x and greater it replace the -ar option')
 	cli.v(longOpt:'versionName', args:1, argName:'versionName', 'Name of the UCD component version')
-	cli.zpv(longOpt:'ucdV2PackageFormat', 'Invoke buztool with the buztool package version v2.')
+	cli.zpv2(longOpt:'ucdV2PackageFormat', 'Invoke buztool with the buztool package version v2.')
 	cli.p(longOpt:'preview', 'Preview mode - generate shiplist, but do not run buztool.sh')
 	cli.pURL(longOpt:'pipelineURL', args:1,'URL to the pipeline build result (Optional)')
 	cli.g(longOpt:'gitBranch', args:1,'Name of the git branch (Optional)')
@@ -395,7 +395,7 @@ def parseInput(String[] cliArgs){
 	if (opts.pURL) properties.pipelineURL = opts.pURL
 	if (opts.g) properties.gitBranch = opts.g
 	properties.preview = (opts.p) ? 'true' : 'false'
-	properties.ucdV2PackageFormat = (opts.zpv) ? 'true' : 'false'
+	properties.ucdV2PackageFormat = (opts.zpv2) ? 'true' : 'false'
 
 
 	// validate required properties

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -136,7 +136,7 @@ println("** Deployable files")
 executes.each { it.getOutputs().each { println("   ${it.dataset}, ${it.deployType}")}}
 
 println("** Deleted files")
-deletions.each { it.getAttributeAsList("deletedBuildOutputs").each { println("   ${it.dataset}")}}
+deletions.each { it.getAttributeAsList("deletedBuildOutputs").each { println("   ${it}")}}
 
 // get DBB.BuildResultProperties records stored as generic DBB Record, see https://github.com/IBM/dbb-zappbuild/pull/95
 def buildResultRecord = buildReport.getRecords().find{

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -503,8 +503,8 @@ def parseInput(String[] cliArgs){
 	cli.zpv2(longOpt:'ucdV2PackageFormat', 'Invoke buztool with the buztool package version v2.')
 	cli.p(longOpt:'preview', 'Preview mode - generate shiplist, but do not run buztool.sh')
 
-	cli.boFile(longOpt:'buildReportOrderFile', args:1, argName:'buildReportOrderFile', 'Build a cumulative package based on a file that lists build reports in order of processing (Optional).')
-	cli.bO(longOpt:'buildReportOrder', args:1, argName:'buildReportOrder', 'Build a cumulative package based on a list of build reports in order of processing (Optional).')
+	cli.bO(longOpt:'buildReportOrder', args:1, argName:'buildReportOrder', 'Build a cumulative package based on a comma separated list of one or multiple DBB build reports processed in the provided order (Optional).')
+	cli.boFile(longOpt:'buildReportOrderFile', args:1, argName:'buildReportOrderFile', 'Build a cumulative package based on an input file that lists one or multiple build reports defining the order of processing (Optional).')
 
 	cli.ppf(longOpt:'packagingPropFiles', args:1,'Comma separated list of property files to configure the dbb-ucd-packaging script (Optional)')
 	cli.rpFile(longOpt:'repositoryInfoPropertiesFile', args:1,'Absolute path to property file containing URL prefixes to git provider (Optional) (** Deprecated, please use --packagingPropFiles instead **)')

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -237,6 +237,13 @@ def cmd = [
 	"-o",
 	"${properties.workDir}/buztool.output"
 ]
+
+// pass buztool pakage version if specified
+// https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format
+if (properties.ucdV2PackageFormat) {
+	cmd << "-zpv v2"
+}
+
 // set artifactRepository option if specified
 if (properties.artifactRepositorySettings) {
 	cmd << "-ar"
@@ -308,6 +315,7 @@ def parseInput(String[] cliArgs){
 	cli.ar(longOpt:'artifactRepository', args:1, argName:'artifactRepositorySettings', 'Absolute path to Artifactory Server connection file')
 	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFileSettings', 'Absolute path to property file (Optional). From UCD v7.1.x and greater it replace the -ar option')
 	cli.v(longOpt:'versionName', args:1, argName:'versionName', 'Name of the UCD component version')
+	cli.zpv(longOpt:'ucdV2PackageFormat', 'Invoke buztool with the buztool package version v2.')
 	cli.p(longOpt:'preview', 'Preview mode - generate shiplist, but do not run buztool.sh')
 	cli.pURL(longOpt:'pipelineURL', args:1,'URL to the pipeline build result (Optional)')
 	cli.g(longOpt:'gitBranch', args:1,'Name of the git branch (Optional)')
@@ -350,7 +358,9 @@ def parseInput(String[] cliArgs){
 	if (opts.pURL) properties.pipelineURL = opts.pURL
 	if (opts.g) properties.gitBranch = opts.g
 	properties.preview = (opts.p) ? 'true' : 'false'
-
+	properties.ucdV2PackageFormat = (opts.zpv) ? 'true' : 'false'
+	
+	
 	// validate required properties
 	try {
 		assert properties.buztoolPath : "Missing property buztool script path"

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -260,16 +260,14 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 	// document deletions
 	
 	deletions.each{ deletion ->
-		if (deletion instanceof AnyTypeRecord) {
-			// obtain the list of build outputs to delete
-			deletedFiles = deletion.getAttributeAsList("deletedBuildOutputs")
-			deletedFiles.each { deletedOutput ->
-				def (ds,member) = getDatasetName(deletedOutput)
-				deleted{
-					// create container
-					container(name:ds, type:"PDS"){
-						resource(name:member, type:"PDSMember")
-					}
+		// obtain the list of build outputs to delete
+		deletedFiles = deletion.getAttributeAsList("deletedBuildOutputs")
+		deletedFiles.each { deletedOutput ->
+			def (ds,member) = getDatasetName(deletedOutput)
+			deleted{
+				// create container
+				container(name:ds, type:"PDS"){
+					resource(name:member, type:"PDSMember")
 				}
 			}
 		}

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -226,9 +226,16 @@ shiplistFile.text = writer
 // command parameters can be found at
 // https://www.ibm.com/support/knowledgecenter/SS4GSP_6.2.7/com.ibm.udeploy.doc/topics/zos_runtools_uss.html
 
+// pass buztool package version2 if specified
+// https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format
+def buztoolOption = "createzosversion"
+if (properties.ucdV2PackageFormat) {
+	buztoolOption = "createzosversion2"
+}
+
 def cmd = [
 	properties.buztoolPath,
-	"createzosversion",
+	buztoolOption,
 	"-c",
 	properties.component,
 	"-s",
@@ -237,12 +244,6 @@ def cmd = [
 	"-o",
 	"${properties.workDir}/buztool.output"
 ]
-
-// pass buztool pakage version if specified
-// https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format
-if (properties.ucdV2PackageFormat) {
-	cmd << "-zpv v2"
-}
 
 // set artifactRepository option if specified
 if (properties.artifactRepositorySettings) {

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -124,7 +124,8 @@ def deletions= buildReport.getRecords().findAll{
 def count = 0
 def deletionCount = 0
 executes.each { count += it.getOutputs().size() }
-deletions.each { deletionCount += it.getOutputs().size()}
+
+deletions.each { deletionCount += it.getAttributeAsList("deletedBuildOutputs").size()}
 
 if ( count + deletionCount == 0 ) {
 	println("** No items to deploy. Skipping ship list generation.")
@@ -135,7 +136,7 @@ println("** Deployable files")
 executes.each { it.getOutputs().each { println("   ${it.dataset}, ${it.deployType}")}}
 
 println("** Deleted files")
-deletions.each { it.getOutputs().each { println("   ${it.dataset}")}}
+deletions.each { it.getAttributeAsList("deletedBuildOutputs").each { println("   ${it.dataset}")}}
 
 // get DBB.BuildResultProperties records stored as generic DBB Record, see https://github.com/IBM/dbb-zappbuild/pull/95
 def buildResultRecord = buildReport.getRecords().find{

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -177,7 +177,7 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 				container(name:ds, type:"PDS")
 			}
 			// define resource elements
-			{
+			resources: {
 				resource(name:member, type:"PDSMember", deployType:output.deployType){
 					// add any custom properties needed
 					property(name:"buildcommand", value:execute.getCommand())

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -114,7 +114,8 @@ executes.each {
 // deletions
 def deletions= buildReport.getRecords().findAll{
 	try {
-		it.getType()==DefaultRecordFactory.TYPE_DELETE
+		// Obtain delete records, which got added by zAppBuild
+		it.getType()=="DELETE_RECORD"
 	} catch (Exception e){
 		println e
 	}
@@ -255,12 +256,19 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 			}
 		}
 	}
+	// document deletions
+	
 	deletions.each{ deletion ->
-		deletion.getOutputs().each { output ->
-			def (ds,member) = getDatasetName(output.dataset)
-			deleted{
-				container(name:ds, type:"PDS"){
-					resource(name:member, type:"PDSMember")
+		if (deletion instanceof AnyTypeRecord) {
+			// obtain the list of build outputs to delete
+			deletedFiles = deletion.getAttributeAsList("deletedBuildOutputs")
+			deletedFiles.each { deletedOutput ->
+				def (ds,member) = getDatasetName(deletedOutput)
+				deleted{
+					// create container
+					container(name:ds, type:"PDS"){
+						resource(name:member, type:"PDSMember")
+					}
 				}
 			}
 		}

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -12,16 +12,16 @@ import groovy.xml.MarkupBuilder
  * usage: dbb-ucd-packaging.groovy [options]
  *
  * options:
- *  -b,--buztool <file>           			Absolute path to UrbanCode Deploy buztool.sh script
- *  -w,--workDir <dir>            			Absolute path to the DBB build output directory
- *  -c,--component <name>         			Name of the UCD component to create version in
- *  -v,--versionName <name>       			Name of the UCD component version name (Optional)
- *  -h,--help                     			Prints this message
- *  -ar,--artifactRepository      			Absolute path to Artifact Respository Server connection file (Optional)
- *  -prop,--propertyFile          			Absolute path to UCD buztool property file (Optional). From UCD v7.1.x and greater it replace the -ar option.
- *  -p,--preview                  			Preview, not executing buztool.sh
- *  -pURL,--pipelineURL			  			URL to the pipeline build result (Optional)
- *  -g,--gitBranch				  			Name of the git branch (Optional)
+ *  -b,--buztool <file>           Absolute path to UrbanCode Deploy buztool.sh script
+ *  -w,--workDir <dir>            Absolute path to the DBB build output directory
+ *  -c,--component <name>         Name of the UCD component to create version in
+ *  -v,--versionName <name>       Name of the UCD component version name (Optional)
+ *  -h,--help                     Prints this message
+ *  -ar,--artifactRepository      Absolute path to Artifact Respository Server connection file (Optional)
+ *  -prop,--propertyFile          Absolute path to property file (Optional). From UCD v7.1.x and greater it replace the -ar option.
+ *  -p,--preview                  Preview, not executing buztool.sh
+ *  -pURL,--pipelineURL           URL to the pipeline build result (Optional)
+ *  -g,--gitBranch                Name of the git branch (Optional)
  *  -rpFile,--repositoryInfoPropertiesFile  Absolute path to property file containing URL prefixes to git provider (Optional).
  *
  * notes:
@@ -57,14 +57,14 @@ import groovy.xml.MarkupBuilder
  *  
  * Version 6 - 2021-06
  *  Take into account  https://github.com/IBM/dbb/issues/78
- * 
- * Version 7 - 2022-03
+ *  
+ * Version 7 - 2022-06 
+ *  Added functionality for --buildReportOrder CLI, allowing multiple build reports to be processed at once to build cumulative packages
  *  Support for UCD packaging format v2 
- *  Ability to package deletions
+ *  Ability to package deletions (requires DBB Toolkit 1.1.3 and zAppBuild 2.4.0)
  *  
  */
 
-// start create version
 def properties = parseInput(args)
 def startTime = new Date()
 properties.startTime = startTime.format("yyyyMMdd.hhmmss.mmm")
@@ -74,87 +74,96 @@ properties.each{k,v->
 	println "   $k -> $v"
 }
 
-// read build report data
-println("** Read build report data from $properties.workDir/BuildReport.json")
-def jsonOutputFile = new File("${properties.workDir}/BuildReport.json")
+/*
+ * HashMap to understand and *merge* the different build outputs from the various buildreports
+ *  
+ <Dataset, {buildReport:Executes}> 
+ dataset as key, then buildReport and Executes as a key-value pair as value 
+ */
+Map<String, Map> buildOutputsMap = new HashMap<String, Map>()
 
-if(!jsonOutputFile.exists()){
-	println("** Build report data at $properties.workDir/BuildReport.json not found")
-	System.exit(1)
-}
-
-def buildReport= BuildReport.parse(new FileInputStream(jsonOutputFile))
-
-// parse build report to find the build result meta info
-def buildResult = buildReport.getRecords().findAll{it.getType()==DefaultRecordFactory.TYPE_BUILD_RESULT}[0];
-
-// parse build report to find the build outputs to be deployed.
-println("** Find deployable outputs in the build report ")
-
-// the following example finds all the build outputs with and without deployType
-//def executes= buildReport.getRecords().findAll{
-//	it.getType()==DefaultRecordFactory.TYPE_EXECUTE
-//}
-
-// Print warning, that extraction of COPY_TO_PDS records are not supported with older versions of the dbb toolkit.
 dbbVersion = new VersionInfo().getVersion()
-println "   * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version $dbbVersion."
+println "* Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version $dbbVersion."
 
-// finds all the build outputs with a deployType
-def executes= buildReport.getRecords().findAll{
-	try {
-		(it.getType()==DefaultRecordFactory.TYPE_EXECUTE || it.getType()==DefaultRecordFactory.TYPE_COPY_TO_PDS) &&
-				!it.getOutputs().isEmpty()
-	} catch (Exception e){}
-}
 
-// Remove excluded outputs
-executes.each {
-	def unwantedOutputs =  it.getOutputs().findAll{ o ->
-		o.deployType == null || o.deployType == 'ZUNIT-TESTCASE'
+println("**  Reading provided build report(s).")
+
+properties.buildReportOrder.each{ buildReportFile ->
+	println("*** Parsing DBB build report $buildReportFile.")
+
+	def buildReport = BuildReport.parse(new FileInputStream(buildReportFile))
+
+	def executes = buildReport.getRecords().findAll{
+		try {
+			(it.getType()==DefaultRecordFactory.TYPE_EXECUTE || it.getType()==DefaultRecordFactory.TYPE_COPY_TO_PDS) &&
+					!it.getOutputs().isEmpty()
+		} catch (Exception e) {}
 	}
-	it.getOutputs().removeAll(unwantedOutputs)
-}
 
-// deletions
-def deletions= buildReport.getRecords().findAll{
-	try {
-		// Obtain delete records, which got added by zAppBuild
-		it.getType()=="DELETE_RECORD"
-	} catch (Exception e){
-		println e
+	//removes all outputs of deploytype ZUNIT-TESTCASE or null
+	executes.each {
+		def unwantedOutputs = it.getOutputs().findAll{ o ->
+			o.deployType == null || o.deployType == 'ZUNIT-TESTCASE'
+		}
+		it.getOutputs().removeAll(unwantedOutputs)
+	}
+
+
+	def deletions = buildReport.getRecords().findAll{
+		try {
+			// Obtain delete records, which got added by zAppBuild
+			it.getType()=="DELETE_RECORD"
+		} catch (Exception e){
+			println e
+		}
+	}
+
+	def count = 0
+	def deletionCount = 0
+
+	// store build output information in Hashmap buildOutputsMap to replace potential duplicates
+	// managing TYPE EXECUTE and COPY_TO_PDS
+	executes.each{ executeRecord ->
+		if(executeRecord.getOutputs().isEmpty() != true) {
+			count += executeRecord.getOutputs().size()
+			executeRecord.getOutputs().each{ output ->
+				buildOutputsMap.put(output.dataset, [buildReport, executeRecord])
+			}
+		}
+	}
+
+	// store build output information in Hashmap buildOutputsMap to replace potential duplicates
+	// managing DELETE_RECORD leveraging the generic AnyTypeRecord Type
+	deletions.each { deleteRecord ->
+		deletionCount += deleteRecord.getAttributeAsList("deletedBuildOutputs").size()
+		deleteRecord.getAttributeAsList("deletedBuildOutputs").each{ deletedFile ->
+			buildOutputsMap.put(deletedFile, [buildReport, deleteRecord])
+		}
+
+	}
+
+	if ( count + deletionCount == 0 ) {
+		println("**  No items to package in $buildReportFile.")
+	} else {
+		// Log deployable files
+		if (count != 0) {
+			println("**  Deployable files detected in $buildReportFile")
+			executes.each { it.getOutputs().each { println("   ${it.dataset}, ${it.deployType}")}}
+		}
+
+		// Log deleted files
+		if (deletionCount != 0) {
+			println("**  Deleted files detected in $buildReportFile")
+			deletions.each { it.getAttributeAsList("deletedBuildOutputs").each { println("   ${it}")}}
+		}
 	}
 }
 
-def count = 0
-def deletionCount = 0
-executes.each { count += it.getOutputs().size() }
-
-deletions.each { deletionCount += it.getAttributeAsList("deletedBuildOutputs").size()}
-
-if ( count + deletionCount == 0 ) {
-	println("** No items to deploy. Skipping ship list generation.")
-	System.exit(0)
+if (buildOutputsMap.size() == 0 ) {
+	println("** No items to package in the provided build reports (s). Process exiting.")
+	exit(2)
 }
 
-println("** Deployable files")
-executes.each { it.getOutputs().each { println("   ${it.dataset}, ${it.deployType}")}}
-
-println("** Deleted files")
-deletions.each { it.getAttributeAsList("deletedBuildOutputs").each { println("   ${it}")}}
-
-// get DBB.BuildResultProperties records stored as generic DBB Record, see https://github.com/IBM/dbb-zappbuild/pull/95
-def buildResultRecord = buildReport.getRecords().find{
-	try {
-		it.getType()==DefaultRecordFactory.TYPE_PROPERTIES && it.getId()=="DBB.BuildResultProperties"
-	} catch (Exception e){}
-}
-
-def buildResultProperties = null
-
-if(buildResultRecord!=null){
-	buildResultProperties = buildResultRecord.getProperties()
-}
 
 // generate ship list file. specification of UCD ship list can be found at
 // https://www.ibm.com/support/knowledgecenter/SS4GSP_6.2.7/com.ibm.udeploy.doc/topics/zos_shiplistfiles.html
@@ -163,96 +172,141 @@ def writer = new StringWriter()
 writer.write("<?xml version=\"1.0\" encoding=\"CP037\"?>\n");
 def xml = new MarkupBuilder(writer)
 xml.manifest(type:"MANIFEST_SHIPLIST"){
-	//top level property will be added as version properties
-	//requires UCD v6.2.6 and above
-	// Url to DBB Build result
-	property(name : "dbb-buildResultUrl", value : buildResult.getUrl())
+
+	println "   Creating general UCD component version properties."
+
 	// Url to CI pipeline
 	if (properties.pipelineURL) property(name : "ci-pipelineUrl", value : properties.pipelineURL )
 	// Git branch
+	if (properties.pullRequestURL) property(name : "ci-pullRequestURL", value : properties.pullRequestURL )
+	// Git branch
 	if (properties.gitBranch) property(name : "ci-gitBranch", value : properties.gitBranch )
-	// Populate build result properties
-	if (buildResultProperties != null) buildResultProperties.each{
-		property(name:it.key, value:it.value)
-	}
-	//iterate through the outputs and add container and resource elements
-	executes.each{ execute ->
-		execute.getOutputs().each{ output ->
-			def (ds,member) = getDatasetName(output.dataset)
-			// define container attributes
-			def containerAttMap
-			if (properties.ucdV2PackageFormat.toBoolean()) {
-				// ucd package format v2 requres to set a deployType at container level
-				def containerDeployType
-				def lastLevelQual = ds.tokenize('.').last()
-				if (properties.containerMapping) {
-					// obtain the deployType setting from the property
-					cMapping = evaluate(properties.containerMapping)
-					containerDeployType = cMapping[lastLevelQual]
-				} else {
-					// set the last level qualifier as deployType
-					containerDeployType = lastLevelQual
+
+	// flag for single build report reporting
+	boolean singleBuildReportReporting = true	
+	
+	// iterate over Hashmap to generate container entries for UCD shiplist.
+	buildOutputsMap.each{ dataset, info ->
+		buildReport = info[0]
+		record = info[1]
+
+		// obtain build info from the build result record
+		def buildResult = buildReport.getRecords().findAll{it.getType()==DefaultRecordFactory.TYPE_BUILD_RESULT}[0]
+		def buildResultRecord = buildReport.getRecords().find{
+			try {
+				it.getType()==DefaultRecordFactory.TYPE_PROPERTIES && it.getId()=="DBB.BuildResultProperties"
+			} catch (Exception e){}
+		}
+		def buildResultProperties = null
+		if(buildResultRecord!=null){
+			buildResultProperties = buildResultRecord.getProperties()
+		}
+
+		// document DBB build properties as component version properties in case of a single build report (keep backward compatibility)
+		if (properties.buildReportOrder.size() == 1 && singleBuildReportReporting) {
+			println "   Storing DBB Build result properties as general component version properties due to single build report."
+			
+			// Url to DBB Build result
+			property(name : "dbb-buildResultUrl", label: buildResult.getLabel(), value : buildResult.getUrl())
+			// Populate build result properties
+			if (buildResultProperties != null) {
+				buildResultProperties.each{
+					//not all properties need to be included in the shiplist
+					//can ignore files processed
+					//can ignore full build / impact build
+					property(name:it.key, value:it.value)
 				}
-				// create container element with deployType
-				containerAttMap = [name:ds, type:"PDS", deployType:containerDeployType]
-			}else {
-				// create container without deployType attribute
-				containerAttMap = [name:ds, type:"PDS"]
 			}
-			// add container node
-			container(containerAttMap){
-				// define resource elements
-				resources: {
-					resource(name:member, type:"PDSMember", deployType:output.deployType){
-						// add any custom properties needed
-						property(name:"buildcommand", value:execute.getCommand())
+			
+			// Shiplist entry created, no need to document it a second time 
+			singleBuildReportReporting = false
+		}
+		
+		println "   Creating shiplist record for build output $dataset with recordType $record.type."
+		
+		// process TYPE_EXECUTE and TYPE_COPY_TO_PDS
+		if (record.getType()==DefaultRecordFactory.TYPE_EXECUTE || record.getType()==DefaultRecordFactory.TYPE_COPY_TO_PDS) {
 
-						// Only TYPE_EXECUTE Records carry options
-						if (execute.getType()==DefaultRecordFactory.TYPE_EXECUTE) property(name:"buildoptions", value:execute.getOptions())
-						// Sample to add additional properties. Here: adding db2 properties for a DBRM
-						//   which where added to the build report through a basic PropertiesRecord.
-						if (output.deployType.equals("DBRM")){
-							propertyRecord = buildReport.getRecords().findAll{
-								it.getType()==DefaultRecordFactory.TYPE_PROPERTIES && it.getProperty("file")==execute.getFile()
-							}
-							propertyRecord.each { propertyRec ->
-								// Iterate Properties
-								(propertyRec.getProperties()).each {
-									property(name:"$it.key", value:it.value)
+			record.getOutputs().each{ output ->
+				// process only outputs of the key of the map
+				if (dataset == output.dataset) {
+					def (ds, member) = getDatasetName(output.dataset)
+					//println "    Defining container for $output.dataset."
+					def containerAttributes = getContainerAttributes(ds, properties)
+					container(containerAttributes){
+						resource(name:member, type:"PDSMember", deployType:output.deployType){
 
+							// document dbb build result url and build properties on the element level when there are more than one buildReport processed
+							if (properties.buildReportOrder.size() != 1) {
+
+								// Url to DBB Build result
+								property(name : "dbb-buildResultUrl", label: buildResult.getLabel(), value : buildResult.getUrl())
+								// Populate build result properties
+								if (buildResultProperties != null) {
+									buildResultProperties.each{
+										//not all properties need to be included in the shiplist
+										//can ignore files processed
+										//can ignore full build / impact build
+										property(name:it.key, value:it.value)
+									}
 								}
 							}
-						}
-						def githash = "" // set empty
-						if (buildResultProperties != null){
-							// get git references from build properties
-							def gitproperty = buildResultProperties.find{
-								it.key.contains(":githash:") && execute.getFile().contains(it.key.substring(9))
+
+							property(name:"buildcommand", value:record.getCommand())
+
+							// Only TYPE_EXECUTE Records carry options
+							if (record.getType()==DefaultRecordFactory.TYPE_EXECUTE) property(name:"buildoptions", value:record.getOptions())
+							
+							// Sample to add additional artifact properties. Here: adding db2 properties for a DBRM
+							//   which where added to the build report through a basic PropertiesRecord.
+							//   see https://github.com/IBM/dbb-zappbuild/blob/06ff114ee22b4e41a09aa0640ac75b7e56c70521/build-conf/build.properties#L79-L89
+								
+							if (output.deployType.equals("DBRM")){
+								propertyRecord = buildReport.getRecords().findAll{
+									it.getType()==DefaultRecordFactory.TYPE_PROPERTIES && it.getProperty("file")==record.getFile()
+								}
+								propertyRecord.each { propertyRec ->
+									// Iterate Properties
+									(propertyRec.getProperties()).each {
+										property(name:"$it.key", value:it.value)
+									}
+								}
 							}
-							if (gitproperty != null ) {
-								githash = gitproperty.getValue()
-								// set properties in shiplist
-								property(name:"githash", value:githash)
-								if(properties.git_commitURL_prefix) property(name:"git-link-to-commit", value:"${properties.git_commitURL_prefix}/${githash}")
+							
+							// add githash to container
+							def githash = "" // set empty
+							if (buildResultProperties != null){
+								// get git references from build properties
+								def gitproperty = buildResultProperties.find{
+									it.key.contains(":githash:") && record.getFile().contains(it.key.substring(9))
+								}
+								if (gitproperty != null ) {
+									githash = gitproperty.getValue()
+									// set properties in shiplist
+									property(name:"githash", value:githash)
+									if(properties.git_commitURL_prefix) property(name:"git-link-to-commit", value:"${properties.git_commitURL_prefix}/${githash}")
+								}
 							}
-						}
-						// add source information in the input column
-						inputUrl = (buildResultProperties != null && properties.git_treeURL_prefix && githash!="") ? "${properties.git_treeURL_prefix}/${githash}/"+ execute.getFile() : ""
-						inputs(url : "${inputUrl}"){
-							input(name : execute.getFile(), compileType : "Main", url : inputUrl)
-							// dependencies
-							def dependencySets = buildReport.getRecords().findAll{
-								it.getType()==DefaultRecordFactory.TYPE_DEPENDENCY_SET && it.getFile()==execute.getFile()
-							};
-							Set<String> dependencyCache = new HashSet<String>()
-							dependencySets.unique().each{
-								it.getAllDependencies().each{
-									if (it.isResolved() && !dependencyCache.contains(it.getLname()) && it.getFile()!=execute.getFile()){
-										def displayName = it.getFile() ? it.getFile() : it.getLname()
-										def dependencyUrl =""
-										if (it.getFile() && (it.getCategory()=="COPY"||it.getCategory()=="SQL INCLUDE")) dependencyUrl = (buildResultProperties != null && properties.git_treeURL_prefix && githash!="") ? "${properties.git_treeURL_prefix}/${githash}/"+ it.getFile() : ""
-										input(name : displayName , compileType : it.getCategory(), url : dependencyUrl)
-										dependencyCache.add(it.getLname())
+							
+							// add source information in the input column of UCD
+							inputUrl = (buildResultProperties != null && properties.git_treeURL_prefix && githash!="") ? "${properties.git_treeURL_prefix}/${githash}/"+ record.getFile() : ""
+							inputs(url : "${inputUrl}"){
+								input(name : record.getFile(), compileType : "Main", url : inputUrl)
+								
+								// adding dependencies
+								def dependencySets = buildReport.getRecords().findAll{
+									it.getType()==DefaultRecordFactory.TYPE_DEPENDENCY_SET && it.getFile()==record.getFile()
+								};
+								Set<String> dependencyCache = new HashSet<String>()
+								dependencySets.unique().each{
+									it.getAllDependencies().each{
+										if (it.isResolved() && !dependencyCache.contains(it.getLname()) && it.getFile()!=record.getFile()){
+											def displayName = it.getFile() ? it.getFile() : it.getLname()
+											def dependencyUrl =""
+											if (it.getFile() && (it.getCategory()=="COPY"||it.getCategory()=="SQL INCLUDE")) dependencyUrl = (buildResultProperties != null && properties.git_treeURL_prefix && githash!="") ? "${properties.git_treeURL_prefix}/${githash}/"+ it.getFile() : ""
+											input(name : displayName , compileType : it.getCategory(), url : dependencyUrl)
+											dependencyCache.add(it.getLname())
+										}
 									}
 								}
 							}
@@ -261,22 +315,62 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 				}
 			}
 		}
-	}
-	// document deletions
-	deletions.each{ deletion ->
-		// obtain the list of build outputs to delete
-		deletedFiles = deletion.getAttributeAsList("deletedBuildOutputs")
-		deletedFiles.each { deletedOutput ->
-			def (ds,member) = getDatasetName(deletedOutput)
-			deleted{
-				// create container
-				container(name:ds, type:"PDS"){
-					resource(name:member, type:"PDSMember")
+		else if (record.getType()=="DELETE_RECORD") {
+			// document delete container
+			
+			deletedFiles = record.getAttributeAsList("deletedBuildOutputs")
+			deletedFiles.each { deletedOutput ->
+
+				// process only outputs of the key of the map
+				if(dataset == deletedOutput) {
+
+					def (ds,member) = getDatasetName(deletedOutput)
+					println "   Defining shiplist delete container for $deletedOutput."
+
+					deleted{
+						// create container
+						def containerAttributes = getContainerAttributes(ds, properties)
+						container(containerAttributes){
+							resource(name:member, type:"PDSMember")
+
+							// document dbb build result url and build properties on the element level when there are more than one buildReport processed
+							if (properties.buildReportOrder.size() != 1) {
+
+								// Url to DBB Build result
+								property(name : "dbb-buildResultUrl", label: buildResult.getLabel(), value : buildResult.getUrl())
+								// Populate build result properties
+								if (buildResultProperties != null) {
+									buildResultProperties.each{
+										//not all properties need to be included in the shiplist
+										//can ignore files processed
+										//can ignore full build / impact build
+										property(name:it.key, value:it.value)
+									}
+								}
+							}
+							
+							// add githash to container
+							def githash = "" // set empty
+							if (buildResultProperties != null){
+								// get git references from build properties
+								def gitproperty = buildResultProperties.find{
+									it.key.contains(":githash:") && record.getAttribute("file").contains(it.key.substring(9))
+								}
+								if (gitproperty != null ) {
+									githash = gitproperty.getValue()
+									// set properties in shiplist
+									property(name:"githash", value:githash)
+									if(properties.git_commitURL_prefix) property(name:"git-link-to-commit", value:"${properties.git_commitURL_prefix}/${githash}")
+								}
+							}
+						}
+					}
 				}
 			}
 		}
 	}
 }
+
 println("** Write ship list file to  $properties.workDir/shiplist.xml")
 def shiplistFile = new File("${properties.workDir}/shiplist.xml")
 shiplistFile.text = writer
@@ -304,23 +398,22 @@ def cmd = [
 	"-o",
 	"${properties.workDir}/buztool.output"
 ]
-
 // set artifactRepository option if specified
 if (properties.artifactRepositorySettings) {
 	cmd << "-ar"
 	cmd << properties.artifactRepositorySettings
 }
 
-// set propertyFile option if specified
-if (properties.propertyFileSettings) {
+// set buztoolPropertyFile option if specified
+if (properties.buztoolPropertyFile) {
 	cmd << "-prop"
-	cmd << properties.propertyFileSettings
+	cmd << properties.buztoolPropertyFile
 }
 
 //set component version name if specified
 if(properties.versionName){
 	cmd << "-v"
-	cmd <<  properties.versionName
+	cmd <<  "\"${properties.versionName}\""
 }
 
 def cmdStr = "";
@@ -330,8 +423,6 @@ println cmdStr
 
 // execute command, if no preview is set
 if (!properties.preview.toBoolean()){
-
-
 	println("** Create version by running UCD buztool")
 
 	StringBuffer response = new StringBuffer()
@@ -368,21 +459,60 @@ def getDatasetName(String fullname){
 	return [ds, member];
 }
 
+/**
+ */
+
+/**
+ * calcualte the container attributes for default package or package v2 
+ */
+// define container attributes
+def getContainerAttributes(String ds, Properties properties) {
+	def containerAttMap = [:]
+	if (properties.ucdV2PackageFormat.toBoolean()) {
+		// ucd package format v2 requres to set a deployType at container level
+		def containerDeployType
+		def lastLevelQual = ds.tokenize('.').last()
+		if (properties.containerMapping) {
+			// obtain the deployType setting from the property
+			cMapping = evaluate(properties.containerMapping)
+			containerDeployType = cMapping[lastLevelQual]
+			if (containerDeployType == null) {
+				println "*!* UCD Packaging v2 formar requires a mapping for the copymode for $lastLevelQual through the containerMapping property - see $properties.containerMapping."
+			}
+		} else {
+			// set the last level qualifier as deployType
+			containerDeployType = lastLevelQual
+		}
+		// create container element with deployType
+		containerAttMap = [name:ds, type:"PDS", deployType:containerDeployType]
+	}else {
+		// create container without deployType attribute
+		containerAttMap = [name:ds, type:"PDS"]
+	}
+	return containerAttMap
+}
+
 def parseInput(String[] cliArgs){
 	def cli = new CliBuilder(usage: "deploy.groovy [options]")
 	cli.b(longOpt:'buztool', args:1, argName:'file', 'Absolute path to UrbanCode Deploy buztool.sh script')
 	cli.w(longOpt:'workDir', args:1, argName:'dir', 'Absolute path to the DBB build output directory')
 	cli.c(longOpt:'component', args:1, argName:'name', 'Name of the UCD component to create version in')
 	cli.ar(longOpt:'artifactRepository', args:1, argName:'artifactRepositorySettings', 'Absolute path to Artifactory Server connection file (** Deprecated, please use --propertyFile instead **)')
-	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFileSettings', 'Absolute path to UCD buztool property file (Optional). From UCD v7.1.x and greater it replaces the -ar option')
+	cli.prop(longOpt:'propertyFile', args:1, argName:'buztoolPropertyFile', 'Absolute path to UCD buztool property file (Optional). From UCD v7.1.x and greater it replaces the -ar option')
 	cli.v(longOpt:'versionName', args:1, argName:'versionName', 'Name of the UCD component version')
 	cli.zpv2(longOpt:'ucdV2PackageFormat', 'Invoke buztool with the buztool package version v2.')
 	cli.p(longOpt:'preview', 'Preview mode - generate shiplist, but do not run buztool.sh')
+
+	cli.boFile(longOpt:'buildReportOrderFile', args:1, argName:'buildReportOrderFile', 'Build a cumulative package based on a file that lists build reports in order of processing (Optional).')
+	cli.bO(longOpt:'buildReportOrder', args:1, argName:'buildReportOrder', 'Build a cumulative package based on a list of build reports in order of processing (Optional).')
+
+	cli.ppf(longOpt:'packagingPropFiles', args:1,'Comma separated list of property files to configure the dbb-ucd-packaging script (Optional)')
+	cli.rpFile(longOpt:'repositoryInfoPropertiesFile', args:1,'Absolute path to property file containing URL prefixes to git provider (Optional) (** Deprecated, please use --packagingPropFiles instead **)')
+	
+	// additional references to build and workflow
 	cli.pURL(longOpt:'pipelineURL', args:1,'URL to the pipeline build result (Optional)')
 	cli.g(longOpt:'gitBranch', args:1,'Name of the git branch (Optional)')
-	cli.rpFile(longOpt:'repositoryInfoPropertiesFile', args:1,'Absolute path to property file containing URL prefixes to git provider (Optional). (** Deprecated, please use cli option --packagingPropFiles**)')
-	cli.ppf(longOpt:'packagingPropFiles', args:1,'Comma separated list of property files to configure the dbb-ucd-packaging script (Optional)')
-
+	cli.prURL(longOpt:'pullRequestURL', args:1,'URL to the Pull/Merge request (Optional)')
 
 	cli.h(longOpt:'help', 'Prints this message')
 	def opts = cli.parse(cliArgs)
@@ -426,12 +556,33 @@ def parseInput(String[] cliArgs){
 	if (opts.b) properties.buztoolPath = opts.b
 	if (opts.c) properties.component = opts.c
 	if (opts.ar) properties.artifactRepositorySettings = opts.ar
-	if (opts.prop) properties.propertyFileSettings = opts.prop
+	if (opts.prop) properties.buztoolPropertyFile = opts.prop
 	if (opts.v) properties.versionName = opts.v
 	if (opts.pURL) properties.pipelineURL = opts.pURL
 	if (opts.g) properties.gitBranch = opts.g
+	if (opts.prURL) properties.pullRequestURL = opts.prURL
 	properties.preview = (opts.p) ? 'true' : 'false'
 	properties.ucdV2PackageFormat = (opts.zpv2) ? 'true' : 'false'
+
+	// setup single or multiple build reports
+	def buildReports = []
+	if (opts.boFile) {
+		new File (opts.boFile).eachLine { line ->
+			buildReports.add(line)
+		}
+	}
+	
+	if (opts.bO) {
+		opts.bO.split(',').each{
+			buildReports.add(it)
+		}
+	} 
+	
+	if (!opts.boFile && !opts.bO){ // default lookup in Workdir
+		buildReports.add(opts.w + "/BuildReport.json")
+	}
+
+	properties.buildReportOrder = buildReports
 
 
 	// validate required properties

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -126,8 +126,6 @@ executes.each { count += it.getOutputs().size() }
 deletions.each { deletionCount += it.getOutputs().size()}
 
 if ( count + deletionCount == 0 ) {
-
-if ( count == 0 ) {
 	println("** No items to deploy. Skipping ship list generation.")
 	System.exit(0)
 }

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -162,7 +162,7 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 			if (properties.ucdV2PackageFormat.toBoolean()) {
 				// ucd package format v2 requres to set a deployType at container level
 				def containerDeployType
-				def lastLevelQual = ds.substring(ds.lastIndexOf('.'))
+				def lastLevelQual = ds.tokenize('.').last()
 				if (properties.containerMapping) {
 					// obtain the deployType setting from the property
 					cMapping = evaluate(properties.containerMapping)

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -12,16 +12,16 @@ import groovy.xml.MarkupBuilder
  * usage: dbb-ucd-packaging.groovy [options]
  *
  * options:
- *  -b,--buztool <file>           Absolute path to UrbanCode Deploy buztool.sh script
- *  -w,--workDir <dir>            Absolute path to the DBB build output directory
- *  -c,--component <name>         Name of the UCD component to create version in
- *  -v,--versionName <name>       Name of the UCD component version name (Optional)
- *  -h,--help                     Prints this message
- *  -ar,--artifactRepository      Absolute path to Artifact Respository Server connection file (Optional)
- *  -prop,--propertyFile          Absolute path to property file (Optional). From UCD v7.1.x and greater it replace the -ar option.
- *  -p,--preview                  Preview, not executing buztool.sh
- *  -pURL,--pipelineURL			  URL to the pipeline build result (Optional)
- *  -g,--gitBranch				  Name of the git branch (Optional)
+ *  -b,--buztool <file>           			Absolute path to UrbanCode Deploy buztool.sh script
+ *  -w,--workDir <dir>            			Absolute path to the DBB build output directory
+ *  -c,--component <name>         			Name of the UCD component to create version in
+ *  -v,--versionName <name>       			Name of the UCD component version name (Optional)
+ *  -h,--help                     			Prints this message
+ *  -ar,--artifactRepository      			Absolute path to Artifact Respository Server connection file (Optional)
+ *  -prop,--propertyFile          			Absolute path to UCD buztool property file (Optional). From UCD v7.1.x and greater it replace the -ar option.
+ *  -p,--preview                  			Preview, not executing buztool.sh
+ *  -pURL,--pipelineURL			  			URL to the pipeline build result (Optional)
+ *  -g,--gitBranch				  			Name of the git branch (Optional)
  *  -rpFile,--repositoryInfoPropertiesFile  Absolute path to property file containing URL prefixes to git provider (Optional).
  *
  * notes:
@@ -57,6 +57,11 @@ import groovy.xml.MarkupBuilder
  *  
  * Version 6 - 2021-06
  *  Take into account  https://github.com/IBM/dbb/issues/78
+ * 
+ * Version 7 - 2022-03
+ *  Support for UCD packaging format v2 
+ *  Ability to package deletions
+ *  
  */
 
 // start create version
@@ -258,7 +263,6 @@ xml.manifest(type:"MANIFEST_SHIPLIST"){
 		}
 	}
 	// document deletions
-	
 	deletions.each{ deletion ->
 		// obtain the list of build outputs to delete
 		deletedFiles = deletion.getAttributeAsList("deletedBuildOutputs")
@@ -369,15 +373,15 @@ def parseInput(String[] cliArgs){
 	cli.b(longOpt:'buztool', args:1, argName:'file', 'Absolute path to UrbanCode Deploy buztool.sh script')
 	cli.w(longOpt:'workDir', args:1, argName:'dir', 'Absolute path to the DBB build output directory')
 	cli.c(longOpt:'component', args:1, argName:'name', 'Name of the UCD component to create version in')
-	cli.ar(longOpt:'artifactRepository', args:1, argName:'artifactRepositorySettings', 'Absolute path to Artifactory Server connection file')
-	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFileSettings', 'Absolute path to property file (Optional). From UCD v7.1.x and greater it replace the -ar option')
+	cli.ar(longOpt:'artifactRepository', args:1, argName:'artifactRepositorySettings', 'Absolute path to Artifactory Server connection file (** Deprecated, please use --propertyFile instead **)')
+	cli.prop(longOpt:'propertyFile', args:1, argName:'propertyFileSettings', 'Absolute path to UCD buztool property file (Optional). From UCD v7.1.x and greater it replaces the -ar option')
 	cli.v(longOpt:'versionName', args:1, argName:'versionName', 'Name of the UCD component version')
 	cli.zpv2(longOpt:'ucdV2PackageFormat', 'Invoke buztool with the buztool package version v2.')
 	cli.p(longOpt:'preview', 'Preview mode - generate shiplist, but do not run buztool.sh')
 	cli.pURL(longOpt:'pipelineURL', args:1,'URL to the pipeline build result (Optional)')
 	cli.g(longOpt:'gitBranch', args:1,'Name of the git branch (Optional)')
-	cli.rpFile(longOpt:'repositoryInfoPropertiesFile', args:1,'Absolute path to property file containing URL prefixes to git provider (Optional). ** Deprecated, please use cli option packagingPropFiles**')
-	cli.ppf(longOpt:'packagingPropFiles', args:1,'Comma separated list of property files to configure the dbb-ucd-packaging script')
+	cli.rpFile(longOpt:'repositoryInfoPropertiesFile', args:1,'Absolute path to property file containing URL prefixes to git provider (Optional). (** Deprecated, please use cli option --packagingPropFiles**)')
+	cli.ppf(longOpt:'packagingPropFiles', args:1,'Comma separated list of property files to configure the dbb-ucd-packaging script (Optional)')
 
 
 	cli.h(longOpt:'help', 'Prints this message')


### PR DESCRIPTION
This PR is enhancing the existing dbb ucd packaging script. It adds the following capabilities:
* Ability to leverage the UCD buztool package format v2.
Reference: [IBM Docs - UCD using package format v2](https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format)
* Ability to process Delete Records from the IBM DBB Build Report to support a decommissioning process - recently introduced in [IBM/dbb-zappbuild](https://github.com/IBM/dbb-zappbuild). 
https://github.com/IBM/dbb-zappbuild/pull/193
* Enhanced documentation including the more detailed processing flow