### PR TITLE
Code Coverage report

### DIFF
--- a/Pipeline/CodeCoverageReport/CodeCoverageReport.groovy
+++ b/Pipeline/CodeCoverageReport/CodeCoverageReport.groovy
@@ -1,0 +1,52 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import groovy.cli.commons.*
+
+// The CCAPI.jar file must be present in the Java ClassPath
+import com.ibm.debug.pdt.codecoverage.core.results.CCAbstractException;
+import com.ibm.debug.pdt.codecoverage.core.results.CCResultException;
+import com.ibm.debug.pdt.codecoverage.core.results.CCResultsFactory;
+import com.ibm.debug.pdt.codecoverage.core.results.ICCModule;
+import com.ibm.debug.pdt.codecoverage.core.results.ICCResult;
+
+// run setup tasks
+setup(args)
+
+// process files passed through command-line
+def String[] filesToProcess = files.split(',');
+
+ICCResult results = null;
+try {
+	results = CCResultsFactory.getInstance().createResult(filesToProcess);
+	ICCModule[] modules = results.getModules();
+	println("** IBM DEBUG Code Coverage details");
+	
+	println("** Included modules:");
+	for (ICCModule iccModule : modules) {
+		println("\t " + iccModule.getName() + " - Code Coverage Percentage: " + iccModule.getPercentCoverage());
+	}
+	println("** Global Code Coverage Percentage: " + results.getPercentCoverage());
+} catch (CCResultException e) {
+	for (CCAbstractException ie : e.getExceptions())
+		println(ie.getMessage());
+	results = e.getResult();
+	e.printStackTrace();
+}
+
+/* setup: handle cli arguments
+*/
+def setup(String[] args) {
+	// parse input arguments
+	String usage = 'CodeCoverageReport.groovy [options]'
+	String header = 'options:'
+	def cli = new CliBuilder(usage:usage,header:header)
+	cli.f(longOpt:'files', args:1, 'Comma-separated list of Code Coverage CCZIP files to analyze')
+	def opts = cli.parse(args)
+	if (!args || !opts) {
+		cli.usage()
+		System.exit(1)
+	}
+	   
+	if (opts.f) files = opts.f
+	
+	assert files : "Missing 'files' argument"
+}

--- a/Pipeline/CodeCoverageReport/README.md
+++ b/Pipeline/CodeCoverageReport/README.md
@@ -1,0 +1,36 @@
+# Code Coverage Report
+
+This script can be used to extract and print information collected by the IBM Debug Code Coverage feature.
+The Code Coverage feature is typically provided in a pipeline by the Headless Code Coverage Daemon, as described in https://www.ibm.com/docs/en/developer-for-zos/15.0.0?topic=gccza-generating-code-coverage-in-headless-mode-using-daemon.
+
+One of the artefacts that the Code Coverage Daemon generates is a ZIP file (that has the .cczip extension), that contains the collected information on code execution.
+These information can be leveraged by developers as part their Unit Testing process, to understand which lines of code of their programs were executed.
+
+The script uses the Code Coverage APIs, which is a set of Java API to parse the results contained in the CCZIP file created by the IBM Debug Code Coverage feature.
+The Code Coverage APIs are described in a JAR file, that is shipped with IBM Debug (in the plugins subfolder of the IBM Debug installation on USS).
+The required `ccapi.jar` file is packaged in a JAR file that must first be extracted (this JAR file is called com.ibm.debug.pdt.codecoverage.core.results_10.1.1.jar for IDz 15.0.3). Once extracted, the `ccapi.jar` must be made available (typically through to the Java classpath), to be correctly imported by the CodeCoverageReport script.
+
+To run the CodeCoverageReport script, a file or a list of comma-separated files must be provided through the `-f`/`--files` parameter. This file or these files must be CCZIP files created by the IBM Debug Code Coverage feature.
+If multiple files are provided, the Code Coverage Percentage is printed for each module found, and the combined Code Coverage Percentage is printed as the "Global Code Coverage Percentage".
+
+### Invokation example (for the DFH0XVDS module):
+``` 
+ groovyz -cp /var/dbb/extensions/ccapi.jar /var/dbb/extensions/CodeCoverageReport.groovy -f DFH0XVDS_2022_03_29_132149_0660.cczip
+```
+
+### Output:
+```
+** IBM DEBUG Code Coverage details
+** Included modules:
+         DFH0XVDS - Code Coverage Percentage: 25
+** Global Code Coverage Percentage: 25
+** Build finished
+```
+
+### CodeCoverageReport.groovy Command Line Options
+```
+usage: CodeCoverageReport.groovy [options]
+options:
+ -f,--files <arg>   Comma-separated list of Code Coverage CCZIP files to
+                    analyze
+```


### PR DESCRIPTION
Leveraging the Code Coverage APIs, this script parses the Code Coverage CCZIP files produced by the IBM Debug Code Coverage feature, to extract the list of modules that were executed and for which coverage information was collected. If multiple files are provided (comma-separated list of paths, through the -f parm), the results are printed for each module found and the results are combined in the Global Code Coverage Percentage.
The CCAPI JAR must be present in the Java Classpath, in order for the utility to work properly.

Reused most of the code done by @dennis-behm 