### PR TITLE
Support for Property Group file and code page

### DIFF
--- a/Pipeline/RunIDZCodeReview/README.md
+++ b/Pipeline/RunIDZCodeReview/README.md
@@ -15,7 +15,7 @@ This sample groovy `RunCodeReview.groogy` script
 - Stores the IDZ Code review reports ```CodeReviewCSV.csv```, ```CodeReviewJUNIT.xml```  as well as the JCL spool in the workdir.
 
 ## Return codes
-The script will exists with the following return codes:
+The script will exit with the following return codes:
 - 0 - No problem encountered
 - 1 - Maximum acceptable return code of Code Review exceeded
 - 2 - Wrong configuration (Missing Property Group file, while no SYSLIB concatenation was found or defined).

--- a/Pipeline/RunIDZCodeReview/README.md
+++ b/Pipeline/RunIDZCodeReview/README.md
@@ -14,6 +14,12 @@ This sample groovy `RunCodeReview.groogy` script
 - Generates an JCLExec for invoking the IDZ Code Review application
 - Stores the IDZ Code review reports ```CodeReviewCSV.csv```, ```CodeReviewJUNIT.xml```  as well as the JCL spool in the workdir.
 
+## Return codes
+The script will exists with the following return codes:
+0 - No problem encountered
+1 - Maximum acceptable return code of Code Review exceeded
+2 - Wrong configuration (Missing Property Group file, while no SYSLIB concatenation was found or defined).
+
 ### Example invocations:
 Invoke RunCodeReview.groovy passing the work directory, which stores the BuildReport.json. The property file ```codereview.properties``` is retrieved from the default location, which is the location of the RunCodeReview.groovy
 ```

--- a/Pipeline/RunIDZCodeReview/README.md
+++ b/Pipeline/RunIDZCodeReview/README.md
@@ -16,9 +16,9 @@ This sample groovy `RunCodeReview.groogy` script
 
 ## Return codes
 The script will exists with the following return codes:
-0 - No problem encountered
-1 - Maximum acceptable return code of Code Review exceeded
-2 - Wrong configuration (Missing Property Group file, while no SYSLIB concatenation was found or defined).
+- 0 - No problem encountered
+- 1 - Maximum acceptable return code of Code Review exceeded
+- 2 - Wrong configuration (Missing Property Group file, while no SYSLIB concatenation was found or defined).
 
 ### Example invocations:
 Invoke RunCodeReview.groovy passing the work directory, which stores the BuildReport.json. The property file ```codereview.properties``` is retrieved from the default location, which is the location of the RunCodeReview.groovy

--- a/Pipeline/RunIDZCodeReview/README.md
+++ b/Pipeline/RunIDZCodeReview/README.md
@@ -1,6 +1,6 @@
 # Run IBM IDZ Code Review in Batch based on the DBB Build Report
 
-This sample groovy script let you embed the IDZ Code Review Application, also known as IDZ Software Analyzer, into your CI/CD pipeline. It requires that the IDZ code analysis tool is installed via FMID HAKGxxx. Please see the documentation at https://www.ibm.com/support/knowledgecenter/SSQ2R2_14.2.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_zosbatch_overview.html
+This sample groovy script lets you embed the IDZ Code Review Application, also known as IDZ Software Analyzer, into your CI/CD pipeline. It requires that the IDZ code analysis tool is installed via FMID HAKGxxx. Please see the documentation at https://www.ibm.com/support/knowledgecenter/SSQ2R2_14.2.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_zosbatch_overview.html
 
 This sample groovy `RunCodeReview.groogy` script
 - extracts information about the processed source code (Record Type TYPE_COPY_TO_PDS) from the DBB BuildReport.json
@@ -30,17 +30,22 @@ $DBB_HOME/bin/groovyz RunCodeReview.groovy --workDir /var/dbb/buildworkspace/zAp
   usage: RunCodeReview.groovy --workDir <path-to-dbb-buildreport> [options]
  
     options:
-      -w,--workDir <dir>      Absolute path to the DBB build output directory
-      -cr,--crRulesFile       (Optional) Absolute path of the rules file. If not provided, will look for it in the codereview.properties file
-      -ccr, --ccrRulesFile    (Optional) Absolute path of the custom rules file. If not provided, will look for it in the codereview.properties file
-      -l,--logEncoding        (Optional) Defines the Encoding for output files (JCL spool, reports),  default UTF-8
-      -props,--properties     (Optional) Absolute path to the codereview.properties file
-      -p,--preview            (Optional) Preview JCL, do not submit it
-      -rc, --maxRC            (Optional) Maximum acceptable return code. If not provided, will look for it in the codereview.properties file
-      -h,--help               (Optional) Prints this message
+      -w,--workDir <dir>            Absolute path to the DBB build output directory
+      -cr,--crRulesFile             (Optional) Absolute path of the rules file. If not provided, will look for it in the codereview.properties file
+      -ccr, --ccrRulesFile          (Optional) Absolute path of the custom rules file. If not provided, will look for it in the codereview.properties file
+      -l,--logEncoding              (Optional) Defines the Encoding for output files (JCL spool, reports),  default UTF-8
+      -props,--properties           (Optional) Absolute path to the codereview.properties file
+      -p,--preview                  (Optional) Preview JCL, do not submit it
+      -rc, --maxRC                  (Optional) Maximum acceptable return code. If not provided, will look for it in the codereview.properties file
+      -h,--help                     (Optional) Prints this message
+      -cp,--codepage <arg>          (Optional) Code Page of the source  members to be processed. By default, IBM-037 is used by Code Review if none is specified.
+                                    If not provided, will look for it in the codereview.properties file.
+      -pgFile,--propertyGroupFile   Absolute path of the Property Group file. This file has to be a Local Property Group file.
+                                    Optional if SYSLIB concatenation is found by the script, otherwise required.
+      
    
     requires:
-  	  codeview.properties file - externalizes the JCL jobcard, RuleFile and Mappings.
+  	  codeview.properties file - externalizes the JCL jobcard, RuleFile and Mappings, maximum acceptable return code, codepage and Property Group file.
   	  If --properties is not provided via cli, the script looks for it at the location of the script itself 
 ```
 

--- a/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
+++ b/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
@@ -18,11 +18,22 @@ import java.nio.file.Path
  * usage: RunCodeReview.groovy --workDir <path-to-dbb-buildreport> [options]
  *
  * 	options:
- *  	-w,--workDir <dir>			Absolute path to the DBB build output directory
- *  	-l,--logEncoding			(Optional) Defines the Encoding for output files (JCL spool, reports), default UTF-8
- *  	-props,--properties			(Optional) Absolute path to the codereview.properties file
- *  	-p,--preview				(Optional) Preview JCL, do not submit it
- *  	-h,--help					(Optional) Prints this message
+ *  	-w,--workDir <dir>					Absolute path to the DBB build output directory
+ *  	-l,--logEncoding					(Optional) Defines the Encoding for output files (JCL spool, reports), default UTF-8
+ *  	-props,--properties					(Optional) Absolute path to the codereview.properties file
+ *  	-p,--preview						(Optional) Preview JCL, do not submit it
+ *  	-h,--help							(Optional) Prints this message
+ *  	-ccr,--ccrRulesFile <arg>   		(Optional) Absolute path of the custom rules file.
+ *  										If not provided, will look for it in the codereview.properties file.
+ *  	-cp,--codepage <arg>        		(Optional) Code Page of the source  members to be processed.
+ *  										By default, IBM-037 is used by Code Review if none is specified.
+ *  										If not provided, will look for it in the codereview.properties file.
+ *  	-cr,--crRulesFile <arg>     		(Optional) Absolute path of the rules file.
+ *  										If not provided, will look for it in the codereview.properties file.
+ *  	-pgFile,--propertyGroupFile <arg>   Absolute path of the Property Group file. This file has to be a Local Property Group file.
+ *  										Optional if SYSLIB concatenation is found by the script, otherwise required.
+ *  	-rc,--maxRC <arg>           		(Optional) Maximum acceptable return code.
+ *  										If not provided, will look for it in the codereview.properties file.
  *
  * 	requires:
  * 		codeview.properties file - externalizes the JCL jobcard, RuleFile and Mappings.
@@ -89,9 +100,15 @@ else
 	}
 	syslib = syslib.toUnique()
 
+	//If no SYSLIB found and no SYSLIB passed in codereview_syslib and no Property Group file passed, fails and exits
+	if (syslib.size() == 0 && !props.codereview_syslib && !props.codereview_PropertyGroupFile) {
+		println "*** SYSLIB Concatenation is empty and no Property Group file was provided. Exiting..."
+		System.exit(1)
+	}
+	
 	println("** Create JCL Stream for IDZ Code Review")
 	String jobcard = props.codereview_jobcard.replace("\\n", "\n")
-	JCLExec codeRev=createCodeReviewExec(jobcard, props.codereview_crRulesFile, props.codereview_ccrRulesFile, sources, syslib)
+	JCLExec codeRev=createCodeReviewExec(jobcard, props.codereview_crRulesFile, props.codereview_ccrRulesFile, props.codereview_PropertyGroupFile, sources, syslib)
 
 	if (props.preview.toBoolean()){
 		println "** Preview only."
@@ -173,7 +190,7 @@ def saveJobOutput ( JCLExec codeRev, String ddName, File file) {
  * CodeReviewExec - creates a JCLExec command for CodeReview
  * TODO: Externalize SYSLIB
  */
-def createCodeReviewExec(String jobcard, String ruleFile, String customRuleFile, List memberList, List syslib) {
+def createCodeReviewExec(String jobcard, String ruleFile, String customRuleFile, String PropertyGroupFile, List memberList, List syslib) {
 	// Execute JCL from a String value in the script
 	def jcl = jobcard
 	jcl += """\
@@ -191,7 +208,12 @@ def createCodeReviewExec(String jobcard, String ruleFile, String customRuleFile,
 	if (props.codereview_syslib){
 		props.codereview_syslib.split(',').each { jcl+="//         DD DISP=SHR,DSN=${it} \n" }
 	}
-	
+
+	if ( PropertyGroupFile ) {
+		def lines = formatJCLPath("//PROPERTY  DD PATH='$PropertyGroupFile'")
+		lines.each{ jcl += it + "\n" }
+	}
+		
 	if ( customRuleFile  ) {
 		def lines = formatJCLPath("//CUSTRULE  DD PATH='$customRuleFile'")
 		lines.each{ jcl += it + "\n" }
@@ -208,6 +230,13 @@ def createCodeReviewExec(String jobcard, String ruleFile, String customRuleFile,
 			jcl += "  L=COBOL M=$hfsFile D=$pdsMember \n"
 		if (languageMapping.isMapped("PLI", it.getSource().getAbsolutePath()))
 			jcl += "  L=PL/1 M=$hfsFile D=$pdsMember \n"
+	}
+
+	if ( props.codereview_codepage  ) {
+		jcl += """\
+//CODEPAGE DD *
+  $props.codereview_codepage
+"""
 	}
 
 	jcl += """\
@@ -233,6 +262,8 @@ def parseInput(String[] cliArgs){
 	cli.props(longOpt:'properties', args:1, '(Optional) Absolute path to the codereview.properties file. If not provided, will look for it at the location of this script.')
 	cli.cr(longOpt:'crRulesFile', args:1, '(Optional) Absolute path of the rules file. If not provided, will look for it in the codereview.properties file.')
 	cli.ccr(longOpt:'ccrRulesFile', args:1, '(Optional) Absolute path of the custom rules file. If not provided, will look for it in the codereview.properties file.')
+	cli.pgFile(longOpt:'propertyGroupFile', args:1, 'Absolute path of the Property Group file. Optional if SYSLIB concatenation is found by the script, otherwise required.')
+	cli.cp(longOpt:'codepage', args:1, '(Optional) Code Page of the source members to be processed. By default, IBM-037 is used by Code Review if none is specified.')
 	cli.l(longOpt:'logEncoding', args:1, '(Optional) Defines the Encoding for output files (JCL spool, reports), default UTF-8')
 	cli.p(longOpt:'preview', '(Optional) Preview JCL for CR, do not submit it')
 	cli.rc(longOpt:'maxRC', args:1, '(Optional) Maximum acceptable return code. If not provided, will look for it in the codereview.properties file.')
@@ -272,6 +303,12 @@ def parseInput(String[] cliArgs){
 	if ( opts.ccr )
 		props.codereview_ccrRulesFile = opts.ccr
 
+	if ( opts.pgFile )
+		props.codereview_PropertyGroupFile = opts.pgFile
+
+	if ( opts.cp )
+		props.codereview_codepage = opts.cp
+	
 	if ( opts.rc )
 		props.codereview_maxRC = opts.rc
 

--- a/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
+++ b/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
@@ -103,7 +103,7 @@ else
 	//If no SYSLIB found and no SYSLIB passed in codereview_syslib and no Property Group file passed, fails and exits
 	if (syslib.size() == 0 && !props.codereview_syslib && !props.codereview_PropertyGroupFile) {
 		println "*** SYSLIB Concatenation is empty and no Property Group file was provided. Exiting..."
-		System.exit(1)
+		System.exit(2)
 	}
 	
 	println("** Create JCL Stream for IDZ Code Review")

--- a/Pipeline/RunIDZCodeReview/codereview.properties
+++ b/Pipeline/RunIDZCodeReview/codereview.properties
@@ -36,3 +36,11 @@ codereview_languageMapping=PLI :: **/*.pli
 ## Specify a comma separated list of additional datasets added to the SYSLIB concatenation for the code review application
 ## codereview_syslib=JENKINS.EXTERNAL.COPY
 codereview_syslib=
+
+#
+## Path to the Property Group file
+#codereview_propertyGroupFile=
+
+#
+## Code page used for files to be processed. If not specified, Code Review will use IBM-037 by default.
+#codereview_codepage=IBM-1047


### PR DESCRIPTION
This PR adds the support for using a Property Group file. This file is made mandatory by Code Review when there is no SYSLIB found by the script (either automatically when copybooks are referenced or when passed through the codereview_syslib property). The path to the Property Group file (XML file) can be set in the codereview.properties file or with a command-line option (which overrides the definition in codereview.properties, if any). The Property Group file must be a local property group file (as generated through IDz) and must be UTF-8 encoded on USS.
This PR also adds the support for specifying a code page for the files to be processed. When not specified, Code Review uses the IBM-037 code page. The code page can be specified through a command-line option or with the codereview_codepage property in codereview.properties.