### PR TITLE
Add missing import statements for Groovy 4

### DIFF
--- a/Migration/sclm/groovy/GenerateBuildProperties.groovy
+++ b/Migration/sclm/groovy/GenerateBuildProperties.groovy
@@ -2,6 +2,7 @@ import java.nio.file.*
 import com.ibm.dbb.*
 import groovy.transform.*
 import groovy.cli.commons.*
+import groovy.xml.*
 
 //******************************************************************************
 //* Retrieves DBB environments

--- a/Migration/sclm/groovy/GenerateBuildScripts.groovy
+++ b/Migration/sclm/groovy/GenerateBuildScripts.groovy
@@ -1,6 +1,7 @@
 import java.nio.file.*
 import groovy.transform.*
 import groovy.cli.commons.*
+import groovy.xml.*
 import java.nio.file.attribute.*
 import com.ibm.dbb.*
 

--- a/Migration/sclm/groovy/SclmExtract.groovy
+++ b/Migration/sclm/groovy/SclmExtract.groovy
@@ -4,6 +4,7 @@ import com.ibm.jzos.*
 import java.nio.file.*
 import groovy.transform.SourceURI
 import groovy.cli.commons.*
+import groovy.xml.*
 
 /*******************************************************************************
  *

--- a/Snippets/zUnitTestCase/RunZUnitJCL.groovy
+++ b/Snippets/zUnitTestCase/RunZUnitJCL.groovy
@@ -1,6 +1,7 @@
 import com.ibm.dbb.build.CopyToHFS
 import com.ibm.dbb.build.DBBConstants
 import com.ibm.dbb.build.JCLExec
+import groovy.xml.*
 
 
 /*********************************************************************************


### PR DESCRIPTION
This PR resolves class resolution issues from missing import statements after upgrading to Groovy 4.0. 

Import statements were added to files using the XmlSlurper & XmlParser classes. 