### PR TITLE
Updated JCLtoDBB.groovy to use the DD parms compatible with BPXWDYN

### DIFF
--- a/Migration/jcl/groovy/JCLtoDBB.groovy
+++ b/Migration/jcl/groovy/JCLtoDBB.groovy
@@ -467,7 +467,16 @@ def convertAllocationToDD(def concat)
 			dd.'pass' = true
 		else
 		{
-			options << "${concat.dispnor}".toLowerCase()
+			def dispnorValue = "${concat.dispnor}".toLowerCase()
+            //* Updated to use catalog/uncatalog instead for catlg/uncatlg for BPXWDYN utility
+			if (dispnorValue == "catlg") {
+				options << "catalog"
+			}
+			else if (dispnorValue == "uncatlg") {
+				options << "uncatalog"
+			} else {
+				options << dispnorValue
+			}			
 		}
 	}
 	if (!concat.parm.text().isEmpty())
@@ -573,7 +582,8 @@ def processAllocOption( parm )
 					}
 					if (allocations.size() > 2 && allocations[2].length() > 0)
 					{
-						options << "directory(${allocations[2]})"
+                        //* updated to use dir instead of directory for BPXWDYN utility
+						options << "dir(${allocations[2]})"
 					}
 					break
 				case 2:


### PR DESCRIPTION
One of our customers reported an issue in the JCLtoDBB.groovy script.  The script is writing the DD parms catlg/uncatlg/directory instead of catalog/uncatalog/dir respectively.  The DD parms - catlg/uncatlg/directory are not supported by BPXWDYN utility and hence the scripts generated by JCLtoDBB.groovy needs to be manually edited for execution.  In this change JCLtoDBB.groovy script is updated to write the parms - catalog/uncatalog/dir instead of catlg/uncatlg/directory.