### PR TITLE
Add an optional option to add the deploy type extension to the member

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -62,7 +62,8 @@ import groovy.cli.commons.*
  *  - Externalize the Map of LLQ to CopyMode
  *  - Add capablity to add additional files from build workspace 
  *  - Verbose logging will print tar contents
- *  
+ * Version 3 - 2022-08
+ *  - Add an optional option to add the deploy type extension to the member
  ************************************************************************************/
 
 // start create & publish package

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -161,7 +161,9 @@ groovyz  /var/jenkins/pipeline/ArtifactoryHelpers.groovy --url http://10.3.20.23
   -verb,--verbose                                Flag to provide more log output.
                                                  (Optional)
   -il,--includeLogs                              Comma-separated list of files/patterns
-                                                 from the USS build workspace                                               
+                                                 from the USS build workspace
+  -ae,--addExtension                             Add the deploy type extension to the member
+                                                 in the package tar file						 
                                         
   Optional Artifactory Upload opts:
  

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -5,7 +5,7 @@
 # required mapping of last level dataset qualifier to DBB CopyToFS CopyMode
 #  DBB supported copy modes are documented at
 #  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
-copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD"]
+copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
 
 # Comma-separated list of deployTypes to limit the scope of the tar
 # file to a subset of the build outputs. (Optional)


### PR DESCRIPTION
Add an optional option to add the deploy type extension to the member. This PR allows exploiting the tar file without the need to interpret the DBB json file.