### PR TITLE
Fix for the CodeReview script - Correct processing of the XML and CSV files

### DIFF
--- a/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
+++ b/Pipeline/RunIDZCodeReview/RunCodeReview.groovy
@@ -1,6 +1,4 @@
 @groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
-import com.ibm.dbb.repository.*
-import com.ibm.dbb.dependency.*
 import com.ibm.dbb.build.*
 import com.ibm.dbb.build.report.*
 import com.ibm.dbb.build.report.records.*
@@ -62,10 +60,6 @@ if(!jsonOutputFile.exists()){
 }
 
 def buildReport= BuildReport.parse(new FileInputStream(jsonOutputFile))
-
-// parse build report to find the build result meta info
-def buildResult = buildReport.getRecords().findAll{it.getType()==DefaultRecordFactory.TYPE_BUILD_RESULT}[0];
-def dependencies = buildReport.getRecords().findAll{it.getType()==DefaultRecordFactory.TYPE_DEPENDENCY_SET};
 
 // parse build report to find the build outputs to be deployed.
 println("** Find source code processed in the build report.")


### PR DESCRIPTION
New PR fixing issues with #136  

The upgrade to the 1.1.3 toolkit introduced the capacity to remove ASA characters when saving spool output of JCLs into flat files on USS. However, this processing is not applicable to XML files and CSV files created by Code Review.
This fix disables the removing of ASA characters in spool outputs for the XML and CSV files generated by Code Review, making them available for additional processing.

Based on comments from Nikos from Handelsbanken, I've also changed the way the output files are saved when they DD names are available, even when the return code is higher than the expected Max RC.