### PR TITLE
Updates to packaging scripts

### DIFF
--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -22,7 +22,7 @@ This section provides a more detailed explanation of how the CreateUCDComponentV
       1. Parse and extract the build output information for deleted build outputs of type *Delete_Record* written to the build report by [zAppBuild (release 2.4.0 onwards)](https://github.com/IBM/dbb-zappbuild/releases/tag/2.4.0). (Requires at least DBB 1.1.3, as the script uses the AnyTypeRecord API introduced in this version.)
       1. Remove output entries that have no `deployType` set and remove unwanted outputs such as outputs with the `deployType` equal to `ZUNIT-TESTCASE`.
    1. If processing multiple build reports, a cumulative list of output records is created to be able to combine outputs from multiple pipeline builds into one UCD component version.
-   	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type
+   	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type.
    	  1. Artifacts having the same member name and the same deploy type will be present only once in the generated UCD shiplist, taking the last occurrence of the artifact, as found in the ordered list of Build Reports passed as parameters.
 
 1. **Generate the UCD `shiplist.xml` file and invoke the UCD packaging step**

--- a/Pipeline/CreateUCDComponentVersion/README.md
+++ b/Pipeline/CreateUCDComponentVersion/README.md
@@ -22,6 +22,8 @@ This section provides a more detailed explanation of how the CreateUCDComponentV
       1. Parse and extract the build output information for deleted build outputs of type *Delete_Record* written to the build report by [zAppBuild (release 2.4.0 onwards)](https://github.com/IBM/dbb-zappbuild/releases/tag/2.4.0). (Requires at least DBB 1.1.3, as the script uses the AnyTypeRecord API introduced in this version.)
       1. Remove output entries that have no `deployType` set and remove unwanted outputs such as outputs with the `deployType` equal to `ZUNIT-TESTCASE`.
    1. If processing multiple build reports, a cumulative list of output records is created to be able to combine outputs from multiple pipeline builds into one UCD component version.
+   	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type
+   	  1. Artifacts having the same member name and the same deploy type will be present only once in the generated UCD shiplist, taking the last occurrence of the artifact, as found in the ordered list of Build Reports passed as parameters.
 
 1. **Generate the UCD `shiplist.xml` file and invoke the UCD packaging step**
    1. Generate the UCD's shiplist records (known as "container records" in UCD documentation) related to build outputs in partitioned datasets. (For more details, see the [IBM Docs UCD Shiplist](https://www.ibm.com/docs/en/urbancode-deploy/7.2.2?topic=SS4GSP_7.2.2/com.ibm.udeploy.doc/topics/zos_shiplistfiles.html)

--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -171,8 +171,8 @@ properties.buildReportOrder.each{ buildReportFile ->
 		if(executeRecord.getOutputs().isEmpty() != true) {
 			count += executeRecord.getOutputs().size()
 			executeRecord.getOutputs().each{ output ->
-				def (ds,member) = getDatasetName(output.dataset)
-				buildOutputsMap.put(new DeployableArtifact(member, output.deployType) , [ds, buildReport, executeRecord])
+				def (dataset, member) = getDatasetName(output.dataset)
+				buildOutputsMap.put(new DeployableArtifact(member, output.deployType) , [dataset, buildReport, executeRecord])
 			}
 		}
 	}
@@ -182,8 +182,8 @@ properties.buildReportOrder.each{ buildReportFile ->
 	deletions.each { deleteRecord ->
 		deletionCount += deleteRecord.getAttributeAsList("deletedBuildOutputs").size()
 		deleteRecord.getAttributeAsList("deletedBuildOutputs").each{ deletedFile ->
-			def (ds,member) = getDatasetName(deletedFile)
-			buildOutputsMap.put(new DeployableArtifact(member, "DELETE") , [ds, buildReport, deleteRecord])
+			def (dataset, member) = getDatasetName(deletedFile)
+			buildOutputsMap.put(new DeployableArtifact(member, "DELETE") , [dataset, buildReport, deleteRecord])
 		}
 	}
 

--- a/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
@@ -6,6 +6,8 @@ import groovy.cli.commons.*
 import java.net.http.*
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.HttpResponse.BodyHandlers
+import java.net.http.HttpResponse.BodyHandler
+import java.util.concurrent.CompletableFuture
 
 import java.nio.file.Paths
 
@@ -17,14 +19,29 @@ import java.nio.file.Paths
  * This script requires JAVA 11 because it uses java.net.http.* APIs to create
  * the HTTPClient and HTTPRequest, replacing the previous ArtifactoryHelper
  *
+ * Version 2 - 2023-04
+ * 
+ * The script has been enhanced to support retries when uploading to an Artifact Repository
+ * 
  */
+
+@Field int MAX_RESEND = 10;
+
+def <T> CompletableFuture<HttpResponse<T>>
+		tryResend(HttpClient client, HttpRequest request, BodyHandler<T> handler,
+				 int count, HttpResponse<T> resp) {
+	if (resp.statusCode() == 200 || count >= MAX_RESEND) {
+		return CompletableFuture.completedFuture(resp);
+	} else {
+		return client.sendAsync(request, handler)
+				.thenComposeAsync(r -> tryResend(client, request, handler, count+1, r));
+	}
+}
 
 run(args)
 
 def upload(String url, String fileName, String user, String password, boolean verbose) throws IOException {
-
-    println( "** ArtifactRepositoryHelper started for upload of $fileName to $url" );
-    
+    println( "** ArtifactRepositoryHelper started for upload of $fileName to $url..." );
     
     // create http client
     HttpClient.Builder httpClientBuilder = HttpClient.newBuilder()
@@ -52,29 +69,27 @@ def upload(String url, String fileName, String user, String password, boolean ve
     .PUT(BodyPublishers.ofFile(Paths.get(fileName)))
     .build();
 
+	println( "** Uploading $fileName to $url..." );
+	
+	HttpResponse.BodyHandler<String> handler = HttpResponse.BodyHandlers.ofString();
     // submit request
+	CompletableFuture<HttpResponse<String>> response = httpClient.sendAsync(request, handler).thenComposeAsync(r -> tryResend(httpClient, request, handler, 1, r));
+	HttpResponse finalResponse = response.get()
     
-    println( "** Uploading $fileName to $url" );
-    HttpResponse response = httpClient.send(request, BodyHandlers.ofString())
+    if ( verbose ) println( "** Response: " + finalResponse );
     
-    if ( verbose ) println( "** Response: " + response );
-    
-    def rc = evaluateHttpResponse(response, "upload", verbose)
-    
+    def rc = evaluateHttpResponse(finalResponse, "upload", verbose)
     if (rc == 0 ) {
         println("** Upload completed");
     }
     else {
         println("** Upload failed");
     }
-
 }
 
 def download(String url, String fileName, String user, String password, boolean verbose) throws IOException  {
-    
-    println( "** ArtifactRepositoryHelper started for download of $url to $fileName" );
-    
-    
+    println( "** ArtifactRepositoryHelper started for download of $url to $fileName..." );
+   
     // create http client
     HttpClient.Builder httpClientBuilder = HttpClient.newBuilder()
     .authenticator(new Authenticator() {
@@ -101,23 +116,25 @@ def download(String url, String fileName, String user, String password, boolean 
     .build();
     
     // submit request
-    println( "** Downloading $url to $fileName " );
-    HttpResponse response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
-    
+    println( "** Downloading $url to $fileName..." );
+	HttpResponse.BodyHandler<String> handler = HttpResponse.BodyHandlers.ofString();
+	CompletableFuture<HttpResponse<String>> response = httpClient.sendAsync(request, handler).thenComposeAsync(r -> tryResend(httpClient, request, handler, 1, r));
+
+	HttpResponse finalResponse = response.get()
+	
     // evalulate response
-    rc = evaluateHttpResponse(response, "download", verbose)
+    rc = evaluateHttpResponse(finalResponse, "download", verbose)
     
     if (rc == 0) {
         // write file to output 
-        def responseBody = response.body()
-        println("** Writing to file to $fileName")
+        def responseBody = finalResponse.body()
+        println("** Writing to file to $fileName...")
         FileOutputStream fos = new FileOutputStream(fileName);
         fos.write(responseBody.readAllBytes());
         fos.close();
     } else {
-        println("** Download failed");
+        println("*! Download failed");
     }
-
 }
 
 def evaluateHttpResponse (HttpResponse response, String action, boolean verbose) {
@@ -138,8 +155,7 @@ def evaluateHttpResponse (HttpResponse response, String action, boolean verbose)
 
 
 //Parsing the command line
-def run(String[] cliArgs)
-{
+def run(String[] cliArgs) {
 
     def cli = new CliBuilder(usage: "ArtifactRepositoryHelpers.groovy [options]", header: '', stopAtNonOption: false)
     cli.h(longOpt:'help', 'Prints this message')
@@ -156,13 +172,12 @@ def run(String[] cliArgs)
         System.exit(1)
     }
 
-    if (opts.h)
-    {
+    if (opts.h) {
         cli.usage()
         System.exit(0)
     }
     
-    if ( opts.fU) {
+    if (opts.fU) {
         upload(opts.u, opts.fU, opts.U, opts.P, opts.v)
     } else {
         download(opts.u, opts.fD, opts.U, opts.P, opts.v)

--- a/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
@@ -19,6 +19,9 @@ import java.nio.file.Paths
  * This script requires JAVA 11 because it uses java.net.http.* APIs to create
  * the HTTPClient and HTTPRequest, replacing the previous ArtifactoryHelper
  *
+ * Version 2 - 2023-04
+ * 
+ * Implemented a retry mechanism for upload and download (with Connection Keep-alive for upload)
  */
 
 @Field int MAX_RESEND = 10;
@@ -126,7 +129,7 @@ def download(String url, String fileName, String user, String password, boolean 
     
     if (rc == 0) {
         // write file to output 
-        def responseBody = response.body()
+        def responseBody = finalResponse.body()
         println("** Writing to file to $fileName")
         FileOutputStream fos = new FileOutputStream(fileName);
         fos.write(responseBody.readAllBytes());
@@ -139,9 +142,9 @@ def download(String url, String fileName, String user, String password, boolean 
 def evaluateHttpResponse (HttpResponse response, String action, boolean verbose) {
     int rc = 0
     def statusCode = response.statusCode()
-    if ( verbose) println "*** HTTP-Status Code: $statusCode"
+    if (verbose) println "*** HTTP-Status Code: $statusCode"
     def responseString = response.body()
-    if ( (statusCode != 201) && (statusCode != 200)  ) {
+    if ((statusCode != 201) && (statusCode != 200)) {
         rc = 1
         println("** Artifactory $action failed with statusCode : $statusCode ")
         println( "** Response: " + response );

--- a/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
@@ -70,27 +70,28 @@ def upload(String url, String fileName, String user, String password, boolean ve
     .PUT(BodyPublishers.ofFile(Paths.get(fileName)))
     .build();
 
-	println( "** Uploading $fileName to $url..." );
+	println("** Uploading $fileName to $url...");
 	
 	HttpResponse.BodyHandler<String> handler = HttpResponse.BodyHandlers.ofString();
     // submit request
 	CompletableFuture<HttpResponse<String>> response = httpClient.sendAsync(request, handler).thenComposeAsync(r -> tryResend(httpClient, request, handler, 1, r));
 	HttpResponse finalResponse = response.get()
     
-    if ( verbose ) println( "** Response: " + finalResponse );
+    if (verbose)
+		println("** Response: " + finalResponse);
     
     def rc = evaluateHttpResponse(finalResponse, "upload", verbose)
     
     if (rc == 0 ) {
-        println("** Upload completed");
+        println("** Upload completed.");
     }
     else {
-        println("** Upload failed");
+        println("*! Upload failed.");
     }
 }
 
 def download(String url, String fileName, String user, String password, boolean verbose) throws IOException  {
-    println( "** ArtifactRepositoryHelper started for download of $url to $fileName" );
+    println("** ArtifactRepositoryHelper started for download of $url to $fileName.");
 
     // create http client
     HttpClient.Builder httpClientBuilder = HttpClient.newBuilder()
@@ -118,7 +119,7 @@ def download(String url, String fileName, String user, String password, boolean 
     .build();
     
     // submit request
-    print( "** Downloading $url to $fileName." );
+    println("** Downloading $url to $fileName...");
 	HttpResponse.BodyHandler<InputStream> handler = HttpResponse.BodyHandlers.ofInputStream();
 	CompletableFuture<HttpResponse<String>> response = httpClient.sendAsync(request, handler).thenComposeAsync(r -> tryResend(httpClient, request, handler, 1, r));
 
@@ -130,12 +131,12 @@ def download(String url, String fileName, String user, String password, boolean 
     if (rc == 0) {
         // write file to output 
         def responseBody = finalResponse.body()
-        println("** Writing to file to $fileName")
+        println("** Writing to file to $fileName.")
         FileOutputStream fos = new FileOutputStream(fileName);
         fos.write(responseBody.readAllBytes());
         fos.close();
     } else {
-        println("** Download failed");
+        println("*! Download failed.");
     }
 }
 
@@ -146,10 +147,9 @@ def evaluateHttpResponse (HttpResponse response, String action, boolean verbose)
     def responseString = response.body()
     if ((statusCode != 201) && (statusCode != 200)) {
         rc = 1
-        println("** Artifactory $action failed with statusCode : $statusCode ")
-        println( "** Response: " + response );
-        throw new RuntimeException("Exception : Artifactory $action failed: "
-             + statusCode);
+        println("** Artifactory $action failed with statusCode : $statusCode")
+        println("** Response: " + response);
+        throw new RuntimeException("Exception : Artifactory $action failed:" + statusCode);
     }    
     return rc
 }

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -24,6 +24,9 @@ This section provides a more detailed explanation of how the PackageBuildOutputs
       1. Parse and extract build output information for records of type *ExecuteRecord* and *CopyToPDSRecord*. (Requires at least DBB 1.0.8.)
       1. Remove output entries that have no `deployType` set and remove unwanted outputs such as outputs with the `deployType` equal to `ZUNIT-TESTCASE`.
    1. If processing multiple build reports, a cumulative hashmap of output records is created to be able to combine outputs from multiple pipeline builds into a single tar file.
+   	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type
+   	  1. Artifacts having the same member name and the same deploy type will be present only once in the generated package, taking the last occurrence of the artifact, as found in the ordered list of Build Reports passed as parameters.
+   
 
 1. **Create Tar-file**
     1. It then invokes CopyToHFS API to copy the outputs from the libraries to a temporary directory on zFS. It will set the file tags based on the ZLANG setting (Note: A workaround is implemented to tag files as binary); all files require to be tagged. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS. When specifying the option `--addExtension`, the `deployType` will be appended as the file extension to the file.

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -26,6 +26,7 @@ This section provides a more detailed explanation of how the PackageBuildOutputs
    1. If processing multiple build reports, a cumulative hashmap of output records is created to be able to combine outputs from multiple pipeline builds into a single tar file.
    	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type.
    	  1. Artifacts having the same member name and the same deploy type will be present only once in the generated package, taking the last occurrence of the artifact, as found in the ordered list of Build Reports passed as parameters.
+   1. The script doesn't manage the deletions of artifacts. Although they are reported in the DBB Build Reports, deletions are not handled by this script.   	  
    
 
 1. **Create Tar-file**

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -24,7 +24,7 @@ This section provides a more detailed explanation of how the PackageBuildOutputs
       1. Parse and extract build output information for records of type *ExecuteRecord* and *CopyToPDSRecord*. (Requires at least DBB 1.0.8.)
       1. Remove output entries that have no `deployType` set and remove unwanted outputs such as outputs with the `deployType` equal to `ZUNIT-TESTCASE`.
    1. If processing multiple build reports, a cumulative hashmap of output records is created to be able to combine outputs from multiple pipeline builds into a single tar file.
-   	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type
+   	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type.
    	  1. Artifacts having the same member name and the same deploy type will be present only once in the generated package, taking the last occurrence of the artifact, as found in the ordered list of Build Reports passed as parameters.
    
 


### PR DESCRIPTION
This PR contains enhancements to the Packaging scripts (CreateUCDComponentVersion and PackageBuildOutputs) to correctly calculate cumulative packages, when using multiple Build Reports. The key used in the Map object, used to accumulate artifacts to be deployed, is formed of the member name and the deploy type, instead of the fully-qualified dataset name and member in the previous versions.
It also contains an enhancement to the ArtifactRepositoryHelpers script, to support retries when performing uploads or downloads to/from an Artifact Repository server.