### PR TITLE
Pipeline templates - ability to specify the directory when cloning

### DIFF
--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -159,6 +159,7 @@ CLI parameter | Description
 -w `<workspace>` | **Workspace directory**, an absolute or relative path that represents unique directory for this pipeline definition, that needs to be consistent through multiple steps. 
 -r `<repoURL>` | **Git repository URL**, can either be SSH or HTTPS-based. Example: `-r git@github.com:Organization/MortgageApplication.git`
 -b `<branch>` | **Git branch** that should be checked out. Example: `-b main`
+-a `<application>` | (Optional) **Application name** to specify the directory into which git will clone. This is required for instance in the scenario if the repository name differs from the application name that is used in the build phase. Example: `-a CBSA`.
 
 **Dealing with private repositories**
 


### PR DESCRIPTION
In some situations the git repository has a different name than what is used as the application for the build phase ( see `-a` for the templates, or `--application` in zAppBuild). Be aware, that subsequent steps of the templates leverage the application parameter to locate the git repository of the application that is processed in the pipeline.

In the case when the project/repository name differs to the application name, leverage the new option on the `gitClone.sh` script to specify the directory during the clone operation. 

The parameter is then used as the directory when cloning: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-ltdirectorygt 