### PR TITLE
Update packaging backend script - application and branch are optional parameters

### DIFF
--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -374,7 +374,8 @@ CLI parameter | Description
 -t `<tarFileName>` | (Optional) Name of the **tar file** to create.
 **Artifact Upload options**
 -u | Flag to enable upload of outputs to the configured artifact repository.
--b | (Required when publishing) Name of the **git branch** turning into a segment of the directory path in the artifact repository. 
+-a `<application>` | **Application name** leveraged to define the artifact repository name. See function `computeArtifactRepositoryName()` in the pipelineBackend.config file. Ex.: `MortgageApplication-repo-local`. 
+-b `<branch>`| Name of the **git branch** turning into a segment of the directory path in the artifact repository. See function `computeArtifactRepositoryDirectory()` in the pipelineBackend.config file.
 -p `<build/release>` | **Pipeline type** to indicate a `build` pipeline (build only with test/debug options) or a `release` pipeline (build for  optimized load modules) to determine the directory in the artifact repository for development and pipeline builds.
 -v `<artifactVersion>` | Label of the **version** in the artifact repository turning into a segment of the directory path in the artifact repo.
 

--- a/Templates/Common-Backend-Scripts/packageBuildOutputs.sh
+++ b/Templates/Common-Backend-Scripts/packageBuildOutputs.sh
@@ -280,18 +280,6 @@ validateOptions() {
         fi
     fi
 
-    if [ -z "${App}" ]; then
-        rc=8
-        ERRMSG=$PGM": [ERROR] Application parameter (-a) is required. rc="$rc
-        echo $ERRMSG
-    fi
-
-    if [ -z "${Branch}" ]; then
-        rc=8
-        ERRMSG=$PGM": [ERROR] Branch Name parameter (-b) is required. rc="$rc
-        echo $ERRMSG
-    fi
-
     # Validate Packaging script
     if [ ! -f "${PackagingScript}" ]; then
         rc=8
@@ -312,6 +300,18 @@ validateOptions() {
 
 # function to validate publishing options
 validatePublishingOptions() {
+
+     if [ -z "${App}" ]; then
+        rc=8
+        ERRMSG=$PGM": [ERROR] Application parameter (-a) is required. rc="$rc
+        echo $ERRMSG
+    fi
+
+    if [ -z "${Branch}" ]; then
+        rc=8
+        ERRMSG=$PGM": [ERROR] Branch Name parameter (-b) is required. rc="$rc
+        echo $ERRMSG
+    fi
 
     if [ ! -z "${artifactRepositoryPropertyFile}" ]; then
         if [ ! -f "${artifactRepositoryPropertyFile}" ]; then
@@ -412,8 +412,12 @@ if [ $rc -eq 0 ]; then
     echo $PGM": [INFO] **************************************************************"
     echo $PGM": [INFO] ** Started - Package Build Outputs on HOST/USER: ${SYS}/${USER}"
     echo $PGM": [INFO] **                  WorkDir:" $(getWorkDirectory)
-    echo $PGM": [INFO] **              Application:" ${App}
-    echo $PGM": [INFO] **                   Branch:" ${Branch}
+    if [ ! -z "${App}" ]; then
+        echo $PGM": [INFO] **              Application:" ${App}
+    fi
+    if [ ! -z "${Branch}" ]; then
+        echo $PGM": [INFO] **                   Branch:" ${Branch}
+    fi
     if [ ! -z "${PipelineType}" ]; then
         echo $PGM": [INFO] **         Type of pipeline:" ${PipelineType}
     fi


### PR DESCRIPTION
As reported in #191 - application and branch parameters become only mandatory when using the upload function to the artifact repository.

