### PR TITLE
Add container mapping entry for EQALANGX output of Assembler.groovy

### DIFF
--- a/Pipeline/CreateUCDComponentVersion/applicationRepositoryProps.properties
+++ b/Pipeline/CreateUCDComponentVersion/applicationRepositoryProps.properties
@@ -28,4 +28,4 @@
 # For the required modifications of the buztool properties file see
 #  https://www.ibm.com/docs/en/urbancode-deploy/7.2.1?topic=czcv-creating-zos-component-version-using-v2-package-format
 #
-containerMapping = {"LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT"}
+containerMapping = {"LOAD": "LOAD", "LOADLIB": "LOAD", "COPY" : "TEXT", "DBRM" : "DBRM", "JCL" : "TEXT", "EQALANGX" : "BINARY"}

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -5,7 +5,7 @@
 # required mapping of last level dataset qualifier to DBB CopyToFS CopyMode
 #  DBB supported copy modes are documented at
 #  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
-copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
+copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
 
 # Comma-separated list of deployTypes to limit the scope of the tar
 # file to a subset of the build outputs. (Optional)


### PR DESCRIPTION
With some recent enhancements in the Assembler.groovy to support the debug side file, it requires to specify the container mapping for the v2 packaging format.

See specified output

https://github.com/IBM/dbb-zappbuild/blob/d177891a59a41b0947eacaf1e1e5a7ca199ac13a/languages/Assembler.groovy#L380