### PR TITLE
Compute build parameters on updated branch naming conventions

### DIFF
--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -220,30 +220,30 @@ This script implements the invocation of the [zAppBuild](https://github.com/IBM/
 
 #### Git branches naming convention requirements
 
-The build script follows the naming conventions for branches that are outlined in the document `The Git-based workflow for Mainframe development`:
+The build script follows the naming conventions for branches that are outlined in the document in the [solution guide](https://ibm.github.io/z-devops-acceleration-program/docs/git-branching-model-for-mainframe-dev#naming-conventions):
 
 ```properties
+## integration branches
+#
 # main Build branch
 main
-
-# feature branches for contributing to the next planned release via main
-feature/setmainbuildbranch
-
 # release maintenance branches to fix a release that is been put to production
 release/rel-1.0.0
-
-# release maintenance feature branches
-#  second segment is indicating the release
-hotfix/rel-1.0.0/fixMortgageApplication
-
 # project/initiative/epic branches
 epic/epic1234
 project/project1
 
-# project/initiative/epic branches
-#  second segment is indicating the project/initiative/epic
-epic1234/myfirstcoolnewfeature
-project1/myfirstcoolnewfeature
+## feature branches
+#
+# feature branches for contributing to the next planned release via main
+feature/setmainbuildbranch
+feature/43-set-main-build-branch
+# release maintenance feature branches
+#  second segment is indicating the release
+hotfix/rel-1.0.0/fixMortgageApplication
+# feature branches for epics / larger development initiatives
+#  second segment is referencing the epic context
+feature/epic1234/54-my-first-cool-new-feature
 ```
 
 Details are documented in [dbbBuildUtils.sh](README.md#script-capabilities--dbbbuildutilssh).

--- a/Templates/Common-Backend-Scripts/test/logs/testGenericWrapper-uss.log
+++ b/Templates/Common-Backend-Scripts/test/logs/testGenericWrapper-uss.log
@@ -32,17 +32,34 @@ MortgageApplication-heads/rel-1.0.0
 MortgageApplication-heads/rel-1.0.0-outputs
 MortgageApplication-release/rel-1.0.0
 MortgageApplication-release/rel-1.0.0-outputs
+MortgageApplication-feature/setmainbuildbranch
 MortgageApplication-implementAI/myFeatureImpl
 MortgageApplication-implementAI/myFeatureImpl-outputs
+MortgageApplication-feature/setmainbuildbranch-outputs
+MortgageApplication-hotfix/rel-1.0.0/myfix
+MortgageApplication-hotfix/rel-1.0.0/myfix-outputs
+MortgageApplication-epic/implementAI
+MortgageApplication-epic/implementAI-outputs
+zunitsample-main
+zunitsample-main-outputs
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection delete MortgageApplication-hotfix/rel-1.0.0/myfix --type file"
+Successfully deleted collection "MortgageApplication-hotfix/rel-1.0.0/myfix"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection delete MortgageApplication-hotfix/rel-1.0.0/myfix-outputs --type file"
+Successfully deleted collection "MortgageApplication-hotfix/rel-1.0.0/myfix-outputs"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection delete MortgageApplication-feature/setmainbuildbranch --type file"
+Successfully deleted collection "MortgageApplication-feature/setmainbuildbranch"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection delete MortgageApplication-feature/setmainbuildbranch-outputs --type file"
+Successfully deleted collection "MortgageApplication-feature/setmainbuildbranch-outputs"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection delete MortgageApplication-epic/implementAI --type file"
+Successfully deleted collection "MortgageApplication-epic/implementAI"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection delete MortgageApplication-epic/implementAI-outputs --type file"
+Successfully deleted collection "MortgageApplication-epic/implementAI-outputs"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb build-group delete MortgageApplication-hotfix/rel-1.0.0/myfix --type file"
+Successfully deleted build group "MortgageApplication-hotfix/rel-1.0.0/myfix"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb build-group delete MortgageApplication-feature/setmainbuildbranch --type file"
+Successfully deleted build group "MortgageApplication-feature/setmainbuildbranch"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb build-group delete MortgageApplication-epic/implementAI --type file"
+Successfully deleted build group "MortgageApplication-epic/implementAI"
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbb collection list --type file"
 IBM Dependency Based Build 2.0.1
 
@@ -74,6 +91,8 @@ MortgageApplication-release/rel-1.0.0
 MortgageApplication-release/rel-1.0.0-outputs
 MortgageApplication-implementAI/myFeatureImpl
 MortgageApplication-implementAI/myFeatureImpl-outputs
+zunitsample-main
+zunitsample-main-outputs
 rc=0
 testGenericWrapper.sh: [TEST] Executing test scenario testMortgageApplication-Main-Bld-Build-0.
 cloneApplicationRepository
@@ -81,7 +100,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-0 -r https://github.com/dennis-behm/MortgageApplication.git -b main"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/main/build-0
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -89,6 +108,7 @@ gitClone.sh: [INFO] **        Branch: main -> main
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch main to /u/dbehm/backendWorkspace/MortApp/main/build-0
+gitClone.sh: [INFO] git clone -b main https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch main
@@ -99,9 +119,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/heads/main
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -112,7 +132,7 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-0 -a MortgageApplication -b main  -p build -t '--fullBuild'"
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-0
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: main
@@ -131,10 +151,12 @@ dbbBuild.sh: [INFO] ************************************************************
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
 dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/main/build-0 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/main/build-0/logs --hlq DBEHM.MORTGAGE.MAIN.BLD --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --fullBuild
 
-** Build start at 20231019.114904.049
+** Build start at 20231218.133138.958
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/main/build-0/logs
-** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231019.114904.049
+** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133138.958
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --fullBuild option selected. Building all programs for application MortgageApplication
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/main/build-0/logs/buildList.txt
 ** Scanning source code.
@@ -152,13 +174,14 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 *** (6/6) Building file MortgageApplication/cobol/epsmpmt.cbl
 ** Building 1 file mapped to LinkEdit.groovy script
 *** (1/1) Building file MortgageApplication/link/epsmlist.lnk
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/main/build-0/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/main/build-0/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231019.114904.049
-** Build ended at Thu Oct 19 11:49:21 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133138.958
+** Build ended at Mon Dec 18 13:31:55 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 9
-** Total build time  : 17.291 seconds
+** Total build time  : 16.831 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/main/build-0/logs/buildList.txt
@@ -169,7 +192,7 @@ Pull Logs
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && prepareLogs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-0"
 prepareLogs.sh: [INFO] Prepare Build logs script. Version=1.00
 prepareLogs.sh: [INFO] **************************************************************
-prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 prepareLogs.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-0
 prepareLogs.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/main/build-0/logs
 prepareLogs.sh: [INFO] **************************************************************
@@ -177,18 +200,18 @@ prepareLogs.sh: [INFO] **  Directory contents:
 prepareLogs.sh: [INFO] ls -RlTr logs
 logs:
 total 1424
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       684 Oct 19 12:49 buildList.txt
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Oct 19 12:49 EPSNBRVL.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     25301 Oct 19 12:49 EPSMPMT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      4154 Oct 19 12:49 EPSMORT.bms.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9523 Oct 19 12:49 EPSMLIST.linkedit.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     72967 Oct 19 12:49 EPSMLIST.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      4154 Oct 19 12:49 EPSMLIS.bms.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     19845 Oct 19 12:49 EPSCSMRT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR    390075 Oct 19 12:49 EPSCSMRD.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53985 Oct 19 12:49 EPSCMORT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     27514 Oct 19 12:49 BuildReport.json
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     27662 Oct 19 12:49 BuildReport.html
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       684 Dec 18 13:31 buildList.txt
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Dec 18 13:31 EPSNBRVL.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     25299 Dec 18 13:31 EPSMPMT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      4152 Dec 18 13:31 EPSMORT.bms.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9521 Dec 18 13:31 EPSMLIST.linkedit.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     72967 Dec 18 13:31 EPSMLIST.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      4152 Dec 18 13:31 EPSMLIS.bms.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     19843 Dec 18 13:31 EPSCSMRT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR    390073 Dec 18 13:31 EPSCSMRD.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53977 Dec 18 13:31 EPSCMORT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     27514 Dec 18 13:31 BuildReport.json
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     27662 Dec 18 13:31 BuildReport.html
 prepareLogs.sh: [INFO] tar -cf logs.tar logs
 prepareLogs.sh: [INFO] Logs successfully stored at /u/dbehm/backendWorkspace/MortApp/main/build-0/logs.tar
 USS file downloaded successfully.
@@ -200,7 +223,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b main"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/main/build-1
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -208,6 +231,7 @@ gitClone.sh: [INFO] **        Branch: main -> main
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch main to /u/dbehm/backendWorkspace/MortApp/main/build-1
+gitClone.sh: [INFO] git clone -b main https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch main
@@ -218,9 +242,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/heads/main
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -231,7 +255,7 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-1 -a MortgageApplication -b main -v -p build"
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-1
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: main
@@ -250,8 +274,11 @@ dbbBuild.sh: [INFO] ************************************************************
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
 dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/main/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --hlq DBEHM.MORTGAGE.MAIN.BLD --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml --verbose --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0
 
-** Build start at 20231019.114945.049
-** Input args = /u/dbehm/backendWorkspace/MortApp/main/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --hlq DBEHM.MORTGAGE.MAIN.BLD --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml --verbose --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0
+** Build start at 20231218.133220.780
+**************** Initialization of the build process ****************
+** Input args = --workspace /u/dbehm/backendWorkspace/MortApp/main/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --hlq DBEHM.MORTGAGE.MAIN.BLD --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml --verbose --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0
+** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/build.properties
+** Loading zAppBuild build properties
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/datasets.properties
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/dependencyReport.properties
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/Assembler.properties
@@ -266,8 +293,13 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/REXX.properties
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/ZunitConfig.properties
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/Transfer.properties
+** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/CRB.properties
+** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/zCEE3.properties
+** Loading default application properties
 ** Loading property file /ZT01/var/dbb/dbb-zappbuild_300/build-conf/defaultzAppBuildConf.properties
-** appConf = /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf
+** Loading application specific properties
+** applicationConfDir = /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf
+** Loading property file /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf/application.properties
 ** Loading property file /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf/file.properties
 ** Loading property file /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf/BMS.properties
 ** Loading property file /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf/Cobol.properties
@@ -278,7 +310,7 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 ** Loading property file /var/dbb/dbb-zappbuild-config/datasets.properties
 ** Loading property file /var/dbb/dbb-zappbuild-config/buildFolder.properties
 java.version=11.0.15+10
-java.home=/V2R4/usr/lpp/java/J11.0_64
+java.home=/V2R5/usr/lpp/java/J11.0_64
 user.dir=/u/dbehm
 ** Build properties at start up:
 IBMZPLI_V51=
@@ -297,7 +329,7 @@ SCSQPLIC=WMQ.V9R2M4.SCSQPLIC
 SDFHCOB=CICSTS.V5R4.CICS.SDFHCOB
 SDFHLOAD=CICSTS.V5R4.CICS.SDFHLOAD
 SDFHMAC=CICSTS.V5R4.CICS.SDFHMAC
-SDFHPL1=
+SDFHPL1=CICSTS.V5R4.CICS.SDFHPL1
 SDFSMAC=IMS.V15R1.SDFSMAC
 SDFSRESL=IMS.V15R1.SDFSRESL
 SDSNEXIT=DBC0CFG.SDSNEXIT
@@ -319,8 +351,9 @@ acbgen_requiredBuildProperties=acbgen_psbPDS,acbgen_dbdPDS,acbgen_loadPDS, acbge
 acbgen_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 application=MortgageApplication
 applicationBuildGroup=MortgageApplication-main
-applicationBuildLabel=build.20231019.114945.049
+applicationBuildLabel=build.20231218.133220.780
 applicationCollectionName=MortgageApplication-main
+applicationConfDir=/u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication/application-conf
 applicationConfRootDir=
 applicationCurrentBranch=main
 applicationDefaultPropFiles=defaultzAppBuildConf.properties
@@ -383,7 +416,6 @@ bms_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 buildListFileExt=txt
 buildOrder=BMS.groovy,Cobol.groovy,LinkEdit.groovy
 buildOutDir=/u/dbehm/backendWorkspace/MortApp/main/build-1/logs
-buildOutputTSformat=yyyyMMdd.HHmmss.mmm
 buildPropFiles=datasets.properties,Assembler.properties,BMS.properties,MFS.properties,PSBgen.properties,DBDgen.properties,ACBgen.properties,Cobol.properties,LinkEdit.properties,PLI.properties,ZunitConfig.properties
 cobol_BMS_PDS=${team}.BMS.COPY
 cobol_compileCICSParms=CICS
@@ -438,7 +470,10 @@ cobol_testcase_loadPDS=DBEHM.MORTGAGE.MAIN.BLD.TEST.LOAD
 cobol_testcase_srcPDS=DBEHM.MORTGAGE.MAIN.BLD.TEST.COBOL
 continueOnScanFailure=true
 copybookSearch=search:/u/dbehm/backendWorkspace/MortApp/main/build-1/?path=MortgageApplication/copybook/*.cpy
+crb_applicationConstraintsFile=/ZT01/var/dbb/dbb-zappbuild_300/build-conf/cicsResourceBuilderConfigurations/MortgageApplication-constraints.yaml
 crb_maxRC=4
+crb_requiredBuildProperties=crb_zrbLocation,crb_resourceModelFile
+crb_resourceModelFile=/ZT01/var/dbb/dbb-zappbuild_300/build-conf/cicsResourceBuilderConfigurations/MortgageApplication-model.yaml
 crb_zrbLocation=/var/crb-1.0.3/cics-resource-builder/bin/zrb
 createBuildOutputSubfolder=false
 createTestcaseDependency=true
@@ -547,7 +582,7 @@ pli_loadOptions=cyl space(1,1) dsorg(PO) recfm(U) blksize(32760) dsntype(library
 pli_loadPDS=DBEHM.MORTGAGE.MAIN.BLD.LOAD
 pli_objPDS=DBEHM.MORTGAGE.MAIN.BLD.OBJ
 pli_outputDatasets=DBEHM.MORTGAGE.MAIN.BLD.LOAD,DBEHM.MORTGAGE.MAIN.BLD.DBRM
-pli_requiredBuildPropeties=pli_srcPDS,pli_incPDS,pli_objPDS,pli_loadPDS,pli_compiler,pli_linkEditor,pli_tempOptions,applicationOutputsCollectionName,SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED,  pli_dependencySearch
+pli_requiredBuildProperties=pli_srcPDS,pli_incPDS,pli_objPDS,pli_loadPDS,pli_compiler,pli_linkEditor,pli_tempOptions,applicationOutputsCollectionName,SDFHCOB,SDFHLOAD,SDSNLOAD,SCEELKED,  pli_dependencySearch
 pli_srcDatasets=DBEHM.MORTGAGE.MAIN.BLD.PLI,DBEHM.MORTGAGE.MAIN.BLD.PLI.INCLUDE,DBEHM.MORTGAGE.MAIN.BLD.OBJ,DBEHM.MORTGAGE.MAIN.BLD.DBRM
 pli_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
 pli_srcPDS=DBEHM.MORTGAGE.MAIN.BLD.PLI
@@ -601,7 +636,7 @@ rexx_srcOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)
 rexx_srcPDS=DBEHM.MORTGAGE.MAIN.BLD.REXX
 rexx_tempOptions=cyl space(5,5) unit(vio) blksize(80) lrecl(80) recfm(f,b) new
 skipImpactCalculationList=
-startTime=20231019.114945.049
+startTime=20231218.133220.780
 topicBranchBuild=null
 transfer_dsOptions=cyl space(1,1) lrecl(144) dsorg(PO) recfm(F,B) dsntype(library)::transfer_xmlPDS
 transfer_dsOptions=cyl space(1,1) lrecl(80) dsorg(PO) recfm(F,B) dsntype(library)::transfer_srcPDS,transfer_jclPDS
@@ -612,6 +647,10 @@ transfer_xmlPDS=DBEHM.MORTGAGE.MAIN.BLD.XML
 verbose=true
 workspace=/u/dbehm/backendWorkspace/MortApp/main/build-1
 zAppBuildDir=/ZT01/var/dbb/dbb-zappbuild_300
+zcee3_gradlePath=
+zcee3_gradle_JAVA_OPTS=-Dfile.encoding=UTF-8
+zcee3_requiredBuildProperties=zcee3_shellEnvironment, zcee3_gradlePath, zcee3_gradle_JAVA_OPTS
+zcee3_shellEnvironment=bash
 zunit_bzucfgPDS=DBEHM.MORTGAGE.MAIN.BLD.BZU.BZUCFG
 zunit_bzuplayPDS=DBEHM.MORTGAGE.MAIN.BLD.BZU.BZUPLAY
 zunit_bzureportPDS=DBEHM.MORTGAGE.MAIN.BLD.BZU.BZURPT
@@ -627,8 +666,9 @@ zunit_srcOptions=cyl space(1,1) lrecl(27998) dsorg(PO) recfm(V,B) dsntype(librar
 required props = buildOrder,buildListFileExt
 ** File MetadataStore initialized
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/main/build-1/logs
-** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231019.114945.049
+** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133220.780
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Getting current hash for directory /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication
 ** Storing MortgageApplication : f7380c46a60e7614539ceb4da6d3aa0dd531a238
@@ -703,8 +743,7 @@ search:/u/dbehm/backendWorkspace/MortApp/main/build-1/?path=MortgageApplication/
   "excluded": false
 }
 Program attributes: CICS=false, SQL=false, DLI=false, MQ=false
-Cobol compiler parms for MortgageApplication/cobol/epsnbrvl.cbl = LIB
-Link-Edit parms for MortgageApplication/cobol/epsnbrvl.cbl = MAP,RENT,COMPAT(PM5),SSI=f7380c46
+*** Cobol compiler parms for MortgageApplication/cobol/epsnbrvl.cbl = LIB
 *** (2/2) Building file MortgageApplication/cobol/epscmort.cbl
 *** Resolution rules for MortgageApplication/cobol/epscmort.cbl:
 search:/u/dbehm/backendWorkspace/MortApp/main/build-1/?path=MortgageApplication/copybook/*.cpy
@@ -767,8 +806,8 @@ search:/u/dbehm/backendWorkspace/MortApp/main/build-1/?path=MortgageApplication/
   "excluded": false
 }
 Program attributes: CICS=true, SQL=true, DLI=false, MQ=false
-Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
-Link-Edit parms for MortgageApplication/cobol/epscmort.cbl = MAP,RENT,COMPAT(PM5),SSI=f7380c46
+*** Cobol compiler parms for MortgageApplication/cobol/epscmort.cbl = LIB,CICS,SQL
+*** Link-Edit parms for MortgageApplication/cobol/epscmort.cbl = MAP,RENT,COMPAT(PM5),SSI=f7380c46
 *** Scanning load module for MortgageApplication/cobol/epscmort.cbl
 *** Logical file = 
 {
@@ -792,17 +831,18 @@ Link-Edit parms for MortgageApplication/cobol/epscmort.cbl = MAP,RENT,COMPAT(PM5
     }
   ]
 }
+***************** Finalization of the build process *****************
 *** Obtaining hash for directory /u/dbehm/backendWorkspace/MortApp/main/build-1/MortgageApplication
 ** Setting property :githash:MortgageApplication : f7380c46a60e7614539ceb4da6d3aa0dd531a238
 ** Setting property :giturl:MortgageApplication : https://github.com/dennis-behm/MortgageApplication.git
 ** Setting property :gitchangedfiles:MortgageApplication : https://github.com/ibm/dbb-zappbuild/compare/f7380c46a60e7614539ceb4da6d3aa0dd531a238..f7380c46a60e7614539ceb4da6d3aa0dd531a238
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231019.114945.049
-** Build ended at Thu Oct 19 11:49:52 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133220.780
+** Build ended at Mon Dec 18 13:32:27 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 2
-** Total build time  : 6.315 seconds
+** Total build time  : 6.234 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/buildList.txt
@@ -810,12 +850,12 @@ dbbBuild.sh: [INFO] DBB Build Complete. rc=0
 rc=0
 Package Step - UCD Packaging
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v MortgageApplication.build-1.2023-10-19_12-49-29 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/main/build-1  -b main -u http://acme.pipeline.org/MortgageApplication.build-1 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v MortgageApplication.build-1.2023-12-18_13-32-07 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/main/build-1  -b main -u http://acme.pipeline.org/MortgageApplication.build-1 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
 ucdPackaging.sh: [INFO] UCD Packaging Wrapper. Version=1.00
 ucdPackaging.sh: [INFO] **************************************************************
-ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 ucdPackaging.sh: [INFO] **                 WorkDir:
-ucdPackaging.sh: [INFO] **             UCD Version: MortgageApplication.build-1.2023-10-19_12-49-29
+ucdPackaging.sh: [INFO] **             UCD Version: MortgageApplication.build-1.2023-12-18_13-32-07
 ucdPackaging.sh: [INFO] **           UCD Component: MortgageApplication
 ucdPackaging.sh: [INFO] **      Artifacts Location: /u/dbehm/backendWorkspace/MortApp/main/build-1/logs
 ucdPackaging.sh: [INFO] **    PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -829,39 +869,39 @@ ucdPackaging.sh: [INFO] **                DBB_HOME: /usr/lpp/dbb/v2r0
 ucdPackaging.sh: [INFO] **************************************************************
 
 ucdPackaging.sh: [INFO] Invoking the DBB UCD Packaging script.
-ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --component MortgageApplication --versionName MortgageApplication.build-1.2023-10-19_12-49-29 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/MortgageApplication.build-1
-** Create version start at 20231019.115000.050
+ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --component MortgageApplication --versionName MortgageApplication.build-1.2023-12-18_13-32-07 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/MortgageApplication.build-1
+** Create version start at 20231218.013234.032
 ** Properties at startup:
    preview -> false
    component -> MortgageApplication
    buztoolPath -> /var/ucd-agent/bin/buztool.sh
    buztoolPropertyFile -> /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json]
-   startTime -> 20231019.115000.050
+   startTime -> 20231218.013234.032
    workDir -> /u/dbehm/backendWorkspace/MortApp/main/build-1/logs
-   versionName -> MortgageApplication.build-1.2023-10-19_12-49-29
+   versionName -> MortgageApplication.build-1.2023-12-18_13-32-07
    pipelineURL -> http://acme.pipeline.org/MortgageApplication.build-1
    ucdV2PackageFormat -> false
 * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 2.0.1.
 **  Reading provided build report(s).
 *** Parsing DBB build report /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json.
-**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json
+**  Deployable dataset members detected in /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json
    DBEHM.MORTGAGE.MAIN.BLD.DBRM(EPSCMORT), DBRM
    DBEHM.MORTGAGE.MAIN.BLD.LOAD(EPSCMORT), CICSLOAD
 ** Generate UCD ship list file
    Creating general UCD component version properties.
    Storing DBB Build result properties as general component version properties due to single build report.
-   Creating shiplist record for build output DBEHM.MORTGAGE.MAIN.BLD.DBRM(EPSCMORT) with recordType EXECUTE.
    Creating shiplist record for build output DBEHM.MORTGAGE.MAIN.BLD.LOAD(EPSCMORT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.MAIN.BLD.DBRM(EPSCMORT) with recordType EXECUTE.
 ** Write ship list file to  /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/shiplist.xml
 ** Following UCD buztool cmd will be invoked
-/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "MortgageApplication.build-1.2023-10-19_12-49-29" 
+/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "MortgageApplication.build-1.2023-12-18_13-32-07" 
 ** Create version by running UCD buztool
 ....Command : createzosversion
 Reading inputs from passed arguments:
 ....Component : MortgageApplication
 ....Shiplist file : /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/shiplist.xml
-....Version name : MortgageApplication.build-1.2023-10-19_12-49-29
+....Version name : MortgageApplication.build-1.2023-12-18_13-32-07
 ....Output File Path : /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/buztool.output
 ....Buztool Properties file : /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
 ....Reading inputs from properties file /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
@@ -870,39 +910,39 @@ zOS toolkit config   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit binary   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit data set : RATCFG.UCD.V7R3M2 (7.3.2.0,20230525-0827)
 Verifying version
-....Repository location : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-1.2023-10-19_12-49-29
+....Repository location : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-1.2023-12-18_13-32-07
 Pre-processing shiplist:
-....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-1.2023-10-19_12-49-29/shiplist.xml
+....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-1.2023-12-18_13-32-07/shiplist.xml
 Packaging data sets:
-....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-1.2023-10-19_12-49-29
+....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-1.2023-12-18_13-32-07
 ....Zip name : package.zip
-....DBEHM.MORTGAGE.MAIN.BLD.DBRM.bin
 ....DBEHM.MORTGAGE.MAIN.BLD.LOAD.bin
-....Elapsed time for data set package or deploy operation : 2.057903 seconds.
+....DBEHM.MORTGAGE.MAIN.BLD.DBRM.bin
+....Elapsed time for data set package or deploy operation : 0.734187 seconds.
 Post-processing package:
 PackageManifest file post-processing completed. 
 Create version and store package in external repository:
 ....Uploading artifacts to ARTIFACTORY
-....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/MortgageApplication.build-1.2023-10-19_12-49-29.zip HTTP/1.1
+....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/MortgageApplication.build-1.2023-12-18_13-32-07.zip HTTP/1.1
 ....Version artifacts stored in External Repository server
-Elapsed time: 6.154 seconds.
+Elapsed time: 5.051 seconds.
 
 ** buztool output properties
    component.name -> MortgageApplication
    version.shiplist -> /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/shiplist.xml
-   version.url -> https://10.3.20.96:8443/#version/98c4db19-508c-45bd-89f1-1b596cbd8b4d
-   version.id -> 98c4db19-508c-45bd-89f1-1b596cbd8b4d
+   version.url -> https://10.3.20.96:8443/#version/1f453537-d443-4cc1-ac99-19afdff63d13
+   version.id -> 1f453537-d443-4cc1-ac99-19afdff63d13
    version.repository.type -> EXTERNAL REPOSITORY
-   version.name -> MortgageApplication.build-1.2023-10-19_12-49-29
+   version.name -> MortgageApplication.build-1.2023-12-18_13-32-07
 ** Build finished
 ucdPackaging.sh: [INFO] DBB UCD Packaging Complete. rc=0
 rc=0
 Package Step - PackageBuildOutputs
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-1 -a MortgageApplication -t package.tar -b main -u -v MortgageApplication.2023-10-19_12-49-29 -p build"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-1 -a MortgageApplication -t package.tar -b main -u -v MortgageApplication.2023-12-18_13-32-07 -p build"
 packageBuildOutputs.sh: [INFO] Package Build Outputs wrapper. Version=1.00
 packageBuildOutputs.sh: [INFO] **************************************************************
-packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 packageBuildOutputs.sh: [INFO] **                  WorkDir: /u/dbehm/backendWorkspace/MortApp/main/build-1
 packageBuildOutputs.sh: [INFO] **              Application: MortgageApplication
 packageBuildOutputs.sh: [INFO] **                   Branch: main
@@ -910,9 +950,8 @@ packageBuildOutputs.sh: [INFO] **         Type of pipeline: build
 packageBuildOutputs.sh: [INFO] **            Tar file Name: package.tar
 packageBuildOutputs.sh: [INFO] **     BuildReport Location: /u/dbehm/backendWorkspace/MortApp/main/build-1/logs
 packageBuildOutputs.sh: [INFO] **     PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
-packageBuildOutputs.sh: [INFO] **     Packaging properties: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
 packageBuildOutputs.sh: [INFO] ** Publish to Artifact Repo: true
-packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-10-19_12-49-29
+packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-12-18_13-32-07
 packageBuildOutputs.sh: [INFO] **         ArtifactRepo Url: http://10.3.20.231:8081/artifactory
 packageBuildOutputs.sh: [INFO] **        ArtifactRepo User: admin
 packageBuildOutputs.sh: [INFO] **    ArtifactRepo Password: xxxxx
@@ -922,8 +961,8 @@ packageBuildOutputs.sh: [INFO] **                 DBB_HOME: /usr/lpp/dbb/v2r0
 packageBuildOutputs.sh: [INFO] **************************************************************
 
 packageBuildOutputs.sh: [INFO] Invoking the Package Build Outputs script.
-packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --tarFileName package.tar --packagingPropertiesFile /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-10-19_12-49-29 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory main/build
-** PackageBuildOutputs start at 20231019.115019.050
+packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/main/build-1/logs --tarFileName package.tar --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-12-18_13-32-07 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory main/build
+** PackageBuildOutputs start at 20231218.013249.032
 ** Properties at startup:
    addExtension -> true
    artifactRepository.directory -> main/build
@@ -932,31 +971,29 @@ packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/Packa
    artifactRepository.url -> http://10.3.20.231:8081/artifactory
    artifactRepository.user -> admin
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json]
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
-   packagingPropertiesFile -> /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+   packagingPropertiesFile -> /ZT01/var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
    publish -> true
-   startTime -> 20231019.115019.050
+   startTime -> 20231218.013249.032
    tarFileName -> package.tar
    verbose -> false
-   versionName -> MortgageApplication.2023-10-19_12-49-29
+   versionName -> MortgageApplication.2023-12-18_13-32-07
    workDir -> /u/dbehm/backendWorkspace/MortApp/main/build-1/logs
-** Read build report data from /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE 
-** Files detected in /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json
+** Read build report data from /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json.
+** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE...
+**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json
    DBEHM.MORTGAGE.MAIN.BLD.DBRM(EPSCMORT), DBRM
    DBEHM.MORTGAGE.MAIN.BLD.LOAD(EPSCMORT), CICSLOAD
 *** Number of build outputs to package: 2
-** Copying BuildOutputs to temporary package dir.
-     Copying DBEHM.MORTGAGE.MAIN.BLD.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.BLD.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY
-     Copying DBEHM.MORTGAGE.MAIN.BLD.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.BLD.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD
-** Copying /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/BuildReport.json to temporary package dir as BuildReport.json.
-** Copying /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar.
+** Copying build outputs to temporary package directory....
+     Copying DBEHM.MORTGAGE.MAIN.BLD.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.BLD.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD...
+     Copying DBEHM.MORTGAGE.MAIN.BLD.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.BLD.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY...
+** Creating tar file at /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar...
 ** Package successfully created at /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar.
-** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/build/MortgageApplication.2023-10-19_12-49-29/package.tar.
-** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/build/MortgageApplication.2023-10-19_12-49-29/package.tar
-** Uploading /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/build/MortgageApplication.2023-10-19_12-49-29/package.tar
-** Upload completed
+** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/build/MortgageApplication.2023-12-18_13-32-07/package.tar...
+** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/build/MortgageApplication.2023-12-18_13-32-07/package.tar
+** Uploading /u/dbehm/backendWorkspace/MortApp/main/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/build/MortgageApplication.2023-12-18_13-32-07/package.tar...
+** Upload completed.
 ** Build finished
 packageBuildOutputs.sh: [INFO] Package Build Outputs Complete. rc=0
 rc=0
@@ -965,7 +1002,7 @@ Run Deployment
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdDeploy.sh -a MortgageApplication -p appDeployment -e Integration-Test -d MortgageApplication:latest -k"
 ucdDeploy.sh: [INFO] Deploy UCD Component. Version=1.00
 ucdDeploy.sh: [INFO] **************************************************************
-ucdDeploy.sh: [INFO] ** Start UCD Component Deploy on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+ucdDeploy.sh: [INFO] ** Start UCD Component Deploy on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 ucdDeploy.sh: [INFO] **   Location of ucd-deploy.groovy: /var/dbb/extensions/dbb20/Pipeline/DeployUCDComponentVersion
 ucdDeploy.sh: [INFO] **            UCD Application Name: MortgageApplication
 ucdDeploy.sh: [INFO] **            UCD Environment Name: Integration-Test
@@ -978,7 +1015,7 @@ ucdDeploy.sh: [INFO] **       SSL Verification disabled: TRUE
 ucdDeploy.sh: [INFO] **************************************************************
 
 /usr/lpp/dbb/v2r0/bin/groovyz /var/dbb/extensions/dbb20/Pipeline/DeployUCDComponentVersion/ucd-deploy.groovy -a "MortgageApplication" -e "Integration-Test" -U admin -P ztecadmin -u https://ucd.dat.ibm.com:8443 -d "MortgageApplication:latest" -p appDeployment -k
-** Request UCD Deployment start at 20231019.115027.050
+** Request UCD Deployment start at 20231218.013256.032
 ** Properties at startup:
    application -> MortgageApplication 
    environment -> Integration-Test 
@@ -991,8 +1028,8 @@ ucdDeploy.sh: [INFO] ***********************************************************
 **  Deploying component versions: MortgageApplication:latest
 *** Starting deployment process 'appDeployment' of application 'MortgageApplication' in environment 'Integration-Test'
 *** SSL Verification disabled
-*** Follow Process Request: https://ucd.dat.ibm.com:8443/#applicationProcessRequest/18b478e9-7f9c-0f09-cbe9-2ee9b94e320e 
-Executing .......
+*** Follow Process Request: https://ucd.dat.ibm.com:8443/#applicationProcessRequest/18c7ce98-d912-ecef-17b2-775799635d77 
+Executing ......
 *** The deployment result is SUCCEEDED. See the UrbanCode Deploy deployment logs for details.
 ** Build finished
 rc=0
@@ -1001,7 +1038,7 @@ Pull Logs
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && prepareLogs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-1"
 prepareLogs.sh: [INFO] Prepare Build logs script. Version=1.00
 prepareLogs.sh: [INFO] **************************************************************
-prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 prepareLogs.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-1
 prepareLogs.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/main/build-1/logs
 prepareLogs.sh: [INFO] **************************************************************
@@ -1009,32 +1046,32 @@ prepareLogs.sh: [INFO] **  Directory contents:
 prepareLogs.sh: [INFO] ls -RlTr logs
 logs:
 total 416
-                    drwxr-xr-x   4 BPXROOT  TIVUSR      8192 Oct 19 12:50 tempPackageDir
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      3125 Oct 19 12:50 shiplist.xml
-m IBM-1047    T=off -rw-r--r--   1 BPXROOT  TIVUSR     64512 Oct 19 12:50 package.tar
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Oct 19 12:49 deletedFilesList.txt
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       440 Oct 19 12:50 buztool.output
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        78 Oct 19 12:49 buildList.txt
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Oct 19 12:49 EPSNBRVL.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53985 Oct 19 12:49 EPSCMORT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Oct 19 12:49 BuildReport.json
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      7861 Oct 19 12:49 BuildReport.html
+                    drwxr-xr-x   4 BPXROOT  TIVUSR      8192 Dec 18 13:32 tempPackageDir
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      3125 Dec 18 13:32 shiplist.xml
+m IBM-1047    T=off -rw-r--r--   1 BPXROOT  TIVUSR     64512 Dec 18 13:32 package.tar
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Dec 18 13:32 deletedFilesList.txt
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       439 Dec 18 13:32 buztool.output
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        78 Dec 18 13:32 buildList.txt
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Dec 18 13:32 EPSNBRVL.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53977 Dec 18 13:32 EPSCMORT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Dec 18 13:32 BuildReport.json
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      7861 Dec 18 13:32 BuildReport.html
 
 logs/tempPackageDir:
-total 82
-t IBM-1047    T=on  -rw-r--r--   1 BPXROOT  TIVUSR      1015 Oct 19 12:50 packageBuildOutputs.properties
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        17 Oct 19 12:50 buildReportOrder.txt
-                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Oct 19 12:50 DBEHM.MORTGAGE.MAIN.BLD.LOAD
-                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Oct 19 12:50 DBEHM.MORTGAGE.MAIN.BLD.DBRM
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Oct 19 12:50 BuildReport.json
+total 96
+- untagged    T=off -rw-r--r--   1 BPXROOT  ZSECURE     1038 Nov 29 12:32 packageBuildOutputs.properties
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        84 Dec 18 13:32 buildReportOrder.txt
+                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Dec 18 13:32 DBEHM.MORTGAGE.MAIN.BLD.LOAD
+                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Dec 18 13:32 DBEHM.MORTGAGE.MAIN.BLD.DBRM
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      9098 Dec 18 13:32 BuildReport.json
 
 logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.BLD.LOAD:
 total 80
-- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     40960 Oct 19 12:50 EPSCMORT.CICSLOAD
+- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     40960 Dec 18 13:32 EPSCMORT.CICSLOAD
 
 logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.BLD.DBRM:
 total 16
-b binary      T=off -rw-r--r--   1 BPXROOT  TIVUSR       480 Oct 19 12:50 EPSCMORT.DBRM
+b binary      T=off -rw-r--r--   1 BPXROOT  TIVUSR       480 Dec 18 13:32 EPSCMORT.DBRM
 prepareLogs.sh: [INFO] tar -cf logs.tar logs
 prepareLogs.sh: [INFO] Logs successfully stored at /u/dbehm/backendWorkspace/MortApp/main/build-1/logs.tar
 USS file downloaded successfully.
@@ -1046,7 +1083,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-2 -r https://github.com/dennis-behm/MortgageApplication.git -b main"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/main/build-2
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -1054,6 +1091,7 @@ gitClone.sh: [INFO] **        Branch: main -> main
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch main to /u/dbehm/backendWorkspace/MortApp/main/build-2
+gitClone.sh: [INFO] git clone -b main https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch main
@@ -1064,9 +1102,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/heads/main
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -1077,7 +1115,7 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-2 -a MortgageApplication -b main  -p release"
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-2
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: main
@@ -1096,10 +1134,12 @@ dbbBuild.sh: [INFO] ************************************************************
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
 dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/main/build-2 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/main/build-2/logs --hlq DBEHM.MORTGAGE.MAIN.REL --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0
 
-** Build start at 20231019.115123.051
+** Build start at 20231218.133353.160
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/main/build-2/logs
-** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231019.115123.051
+** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133353.160
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/buildList.txt
 ** Writing list of deleted files to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/deletedFilesList.txt
@@ -1108,13 +1148,14 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 ** Building 2 files mapped to Cobol.groovy script
 *** (1/2) Building file MortgageApplication/cobol/epsnbrvl.cbl
 *** (2/2) Building file MortgageApplication/cobol/epscmort.cbl
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231019.115123.051
-** Build ended at Thu Oct 19 11:51:29 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133353.160
+** Build ended at Mon Dec 18 13:33:59 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 2
-** Total build time  : 6.060 seconds
+** Total build time  : 6.510 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/buildList.txt
@@ -1122,12 +1163,12 @@ dbbBuild.sh: [INFO] DBB Build Complete. rc=0
 rc=0
 Package Step - UCD Packaging
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v MortgageApplication.build-2.2023-10-19_12-51-10 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/main/build-2  -b main -u http://acme.pipeline.org/MortgageApplication.build-2 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v MortgageApplication.build-2.2023-12-18_13-33-34 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/main/build-2  -b main -u http://acme.pipeline.org/MortgageApplication.build-2 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
 ucdPackaging.sh: [INFO] UCD Packaging Wrapper. Version=1.00
 ucdPackaging.sh: [INFO] **************************************************************
-ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 ucdPackaging.sh: [INFO] **                 WorkDir:
-ucdPackaging.sh: [INFO] **             UCD Version: MortgageApplication.build-2.2023-10-19_12-51-10
+ucdPackaging.sh: [INFO] **             UCD Version: MortgageApplication.build-2.2023-12-18_13-33-34
 ucdPackaging.sh: [INFO] **           UCD Component: MortgageApplication
 ucdPackaging.sh: [INFO] **      Artifacts Location: /u/dbehm/backendWorkspace/MortApp/main/build-2/logs
 ucdPackaging.sh: [INFO] **    PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -1141,23 +1182,23 @@ ucdPackaging.sh: [INFO] **                DBB_HOME: /usr/lpp/dbb/v2r0
 ucdPackaging.sh: [INFO] **************************************************************
 
 ucdPackaging.sh: [INFO] Invoking the DBB UCD Packaging script.
-ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/main/build-2/logs --component MortgageApplication --versionName MortgageApplication.build-2.2023-10-19_12-51-10 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/MortgageApplication.build-2
-** Create version start at 20231019.115137.051
+ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/main/build-2/logs --component MortgageApplication --versionName MortgageApplication.build-2.2023-12-18_13-33-34 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/MortgageApplication.build-2
+** Create version start at 20231218.013413.034
 ** Properties at startup:
    preview -> false
    component -> MortgageApplication
    buztoolPath -> /var/ucd-agent/bin/buztool.sh
    buztoolPropertyFile -> /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json]
-   startTime -> 20231019.115137.051
+   startTime -> 20231218.013413.034
    workDir -> /u/dbehm/backendWorkspace/MortApp/main/build-2/logs
-   versionName -> MortgageApplication.build-2.2023-10-19_12-51-10
+   versionName -> MortgageApplication.build-2.2023-12-18_13-33-34
    pipelineURL -> http://acme.pipeline.org/MortgageApplication.build-2
    ucdV2PackageFormat -> false
 * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 2.0.1.
 **  Reading provided build report(s).
 *** Parsing DBB build report /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json.
-**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json
+**  Deployable dataset members detected in /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json
    DBEHM.MORTGAGE.MAIN.REL.DBRM(EPSCMORT), DBRM
    DBEHM.MORTGAGE.MAIN.REL.LOAD(EPSCMORT), CICSLOAD
 ** Generate UCD ship list file
@@ -1167,13 +1208,13 @@ ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDCom
    Creating shiplist record for build output DBEHM.MORTGAGE.MAIN.REL.DBRM(EPSCMORT) with recordType EXECUTE.
 ** Write ship list file to  /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/shiplist.xml
 ** Following UCD buztool cmd will be invoked
-/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "MortgageApplication.build-2.2023-10-19_12-51-10" 
+/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "MortgageApplication.build-2.2023-12-18_13-33-34" 
 ** Create version by running UCD buztool
 ....Command : createzosversion
 Reading inputs from passed arguments:
 ....Component : MortgageApplication
 ....Shiplist file : /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/shiplist.xml
-....Version name : MortgageApplication.build-2.2023-10-19_12-51-10
+....Version name : MortgageApplication.build-2.2023-12-18_13-33-34
 ....Output File Path : /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/buztool.output
 ....Buztool Properties file : /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
 ....Reading inputs from properties file /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
@@ -1182,39 +1223,39 @@ zOS toolkit config   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit binary   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit data set : RATCFG.UCD.V7R3M2 (7.3.2.0,20230525-0827)
 Verifying version
-....Repository location : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-2.2023-10-19_12-51-10
+....Repository location : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-2.2023-12-18_13-33-34
 Pre-processing shiplist:
-....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-2.2023-10-19_12-51-10/shiplist.xml
+....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-2.2023-12-18_13-33-34/shiplist.xml
 Packaging data sets:
-....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-2.2023-10-19_12-51-10
+....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.build-2.2023-12-18_13-33-34
 ....Zip name : package.zip
 ....DBEHM.MORTGAGE.MAIN.REL.LOAD.bin
 ....DBEHM.MORTGAGE.MAIN.REL.DBRM.bin
-....Elapsed time for data set package or deploy operation : 0.832231 seconds.
+....Elapsed time for data set package or deploy operation : 0.742856 seconds.
 Post-processing package:
 PackageManifest file post-processing completed. 
 Create version and store package in external repository:
 ....Uploading artifacts to ARTIFACTORY
-....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/MortgageApplication.build-2.2023-10-19_12-51-10.zip HTTP/1.1
+....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/MortgageApplication.build-2.2023-12-18_13-33-34.zip HTTP/1.1
 ....Version artifacts stored in External Repository server
-Elapsed time: 3.246 seconds.
+Elapsed time: 4.359 seconds.
 
 ** buztool output properties
    component.name -> MortgageApplication
    version.shiplist -> /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/shiplist.xml
-   version.url -> https://10.3.20.96:8443/#version/6c047c7d-7797-4c71-81ef-969652ddc152
-   version.id -> 6c047c7d-7797-4c71-81ef-969652ddc152
+   version.url -> https://10.3.20.96:8443/#version/2f0faeaa-08ca-43d1-b0da-ad5e173474fd
+   version.id -> 2f0faeaa-08ca-43d1-b0da-ad5e173474fd
    version.repository.type -> EXTERNAL REPOSITORY
-   version.name -> MortgageApplication.build-2.2023-10-19_12-51-10
+   version.name -> MortgageApplication.build-2.2023-12-18_13-33-34
 ** Build finished
 ucdPackaging.sh: [INFO] DBB UCD Packaging Complete. rc=0
 rc=0
 Package Step - PackageBuildOutputs
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-2 -a MortgageApplication -t package.tar -b main -u -v MortgageApplication.2023-10-19_12-51-10 -p release"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-2 -a MortgageApplication -t package.tar -b main -u -v MortgageApplication.2023-12-18_13-33-34 -p release"
 packageBuildOutputs.sh: [INFO] Package Build Outputs wrapper. Version=1.00
 packageBuildOutputs.sh: [INFO] **************************************************************
-packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 packageBuildOutputs.sh: [INFO] **                  WorkDir: /u/dbehm/backendWorkspace/MortApp/main/build-2
 packageBuildOutputs.sh: [INFO] **              Application: MortgageApplication
 packageBuildOutputs.sh: [INFO] **                   Branch: main
@@ -1222,9 +1263,8 @@ packageBuildOutputs.sh: [INFO] **         Type of pipeline: release
 packageBuildOutputs.sh: [INFO] **            Tar file Name: package.tar
 packageBuildOutputs.sh: [INFO] **     BuildReport Location: /u/dbehm/backendWorkspace/MortApp/main/build-2/logs
 packageBuildOutputs.sh: [INFO] **     PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
-packageBuildOutputs.sh: [INFO] **     Packaging properties: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
 packageBuildOutputs.sh: [INFO] ** Publish to Artifact Repo: true
-packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-10-19_12-51-10
+packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-12-18_13-33-34
 packageBuildOutputs.sh: [INFO] **         ArtifactRepo Url: http://10.3.20.231:8081/artifactory
 packageBuildOutputs.sh: [INFO] **        ArtifactRepo User: admin
 packageBuildOutputs.sh: [INFO] **    ArtifactRepo Password: xxxxx
@@ -1234,8 +1274,8 @@ packageBuildOutputs.sh: [INFO] **                 DBB_HOME: /usr/lpp/dbb/v2r0
 packageBuildOutputs.sh: [INFO] **************************************************************
 
 packageBuildOutputs.sh: [INFO] Invoking the Package Build Outputs script.
-packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/main/build-2/logs --tarFileName package.tar --packagingPropertiesFile /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-10-19_12-51-10 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory main/release
-** PackageBuildOutputs start at 20231019.115150.051
+packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/main/build-2/logs --tarFileName package.tar --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-12-18_13-33-34 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory main/release
+** PackageBuildOutputs start at 20231218.013431.034
 ** Properties at startup:
    addExtension -> true
    artifactRepository.directory -> main/release
@@ -1244,31 +1284,29 @@ packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/Packa
    artifactRepository.url -> http://10.3.20.231:8081/artifactory
    artifactRepository.user -> admin
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json]
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
-   packagingPropertiesFile -> /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+   packagingPropertiesFile -> /ZT01/var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
    publish -> true
-   startTime -> 20231019.115150.051
+   startTime -> 20231218.013431.034
    tarFileName -> package.tar
    verbose -> false
-   versionName -> MortgageApplication.2023-10-19_12-51-10
+   versionName -> MortgageApplication.2023-12-18_13-33-34
    workDir -> /u/dbehm/backendWorkspace/MortApp/main/build-2/logs
-** Read build report data from /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE 
-** Files detected in /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json
+** Read build report data from /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json.
+** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE...
+**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json
    DBEHM.MORTGAGE.MAIN.REL.DBRM(EPSCMORT), DBRM
    DBEHM.MORTGAGE.MAIN.REL.LOAD(EPSCMORT), CICSLOAD
 *** Number of build outputs to package: 2
-** Copying BuildOutputs to temporary package dir.
-     Copying DBEHM.MORTGAGE.MAIN.REL.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.REL.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD
-     Copying DBEHM.MORTGAGE.MAIN.REL.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.REL.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY
-** Copying /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/BuildReport.json to temporary package dir as BuildReport.json.
-** Copying /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar.
+** Copying build outputs to temporary package directory....
+     Copying DBEHM.MORTGAGE.MAIN.REL.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.REL.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD...
+     Copying DBEHM.MORTGAGE.MAIN.REL.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.REL.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY...
+** Creating tar file at /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar...
 ** Package successfully created at /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar.
-** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/release/MortgageApplication.2023-10-19_12-51-10/package.tar.
-** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/release/MortgageApplication.2023-10-19_12-51-10/package.tar
-** Uploading /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/release/MortgageApplication.2023-10-19_12-51-10/package.tar
-** Upload completed
+** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/release/MortgageApplication.2023-12-18_13-33-34/package.tar...
+** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/release/MortgageApplication.2023-12-18_13-33-34/package.tar
+** Uploading /u/dbehm/backendWorkspace/MortApp/main/build-2/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/main/release/MortgageApplication.2023-12-18_13-33-34/package.tar...
+** Upload completed.
 ** Build finished
 packageBuildOutputs.sh: [INFO] Package Build Outputs Complete. rc=0
 rc=0
@@ -1277,7 +1315,7 @@ Pull Logs
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && prepareLogs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-2"
 prepareLogs.sh: [INFO] Prepare Build logs script. Version=1.00
 prepareLogs.sh: [INFO] **************************************************************
-prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 prepareLogs.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-2
 prepareLogs.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/main/build-2/logs
 prepareLogs.sh: [INFO] **************************************************************
@@ -1285,32 +1323,32 @@ prepareLogs.sh: [INFO] **  Directory contents:
 prepareLogs.sh: [INFO] ls -RlTr logs
 logs:
 total 416
-                    drwxr-xr-x   4 BPXROOT  TIVUSR      8192 Oct 19 12:51 tempPackageDir
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      3125 Oct 19 12:51 shiplist.xml
-m IBM-1047    T=off -rw-r--r--   1 BPXROOT  TIVUSR     64512 Oct 19 12:51 package.tar
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Oct 19 12:51 deletedFilesList.txt
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       440 Oct 19 12:51 buztool.output
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        78 Oct 19 12:51 buildList.txt
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Oct 19 12:51 EPSNBRVL.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53985 Oct 19 12:51 EPSCMORT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Oct 19 12:51 BuildReport.json
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      7861 Oct 19 12:51 BuildReport.html
+                    drwxr-xr-x   4 BPXROOT  TIVUSR      8192 Dec 18 13:34 tempPackageDir
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      3125 Dec 18 13:34 shiplist.xml
+m IBM-1047    T=off -rw-r--r--   1 BPXROOT  TIVUSR     64512 Dec 18 13:34 package.tar
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Dec 18 13:33 deletedFilesList.txt
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       439 Dec 18 13:34 buztool.output
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        78 Dec 18 13:33 buildList.txt
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Dec 18 13:33 EPSNBRVL.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53977 Dec 18 13:33 EPSCMORT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Dec 18 13:33 BuildReport.json
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      7861 Dec 18 13:33 BuildReport.html
 
 logs/tempPackageDir:
-total 82
-t IBM-1047    T=on  -rw-r--r--   1 BPXROOT  TIVUSR      1015 Oct 19 12:51 packageBuildOutputs.properties
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        17 Oct 19 12:51 buildReportOrder.txt
-                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Oct 19 12:51 DBEHM.MORTGAGE.MAIN.REL.LOAD
-                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Oct 19 12:51 DBEHM.MORTGAGE.MAIN.REL.DBRM
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Oct 19 12:51 BuildReport.json
+total 96
+- untagged    T=off -rw-r--r--   1 BPXROOT  ZSECURE     1038 Nov 29 12:32 packageBuildOutputs.properties
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        84 Dec 18 13:34 buildReportOrder.txt
+                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Dec 18 13:34 DBEHM.MORTGAGE.MAIN.REL.LOAD
+                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Dec 18 13:34 DBEHM.MORTGAGE.MAIN.REL.DBRM
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      9098 Dec 18 13:33 BuildReport.json
 
 logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.REL.LOAD:
 total 80
-- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     40960 Oct 19 12:51 EPSCMORT.CICSLOAD
+- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     40960 Dec 18 13:34 EPSCMORT.CICSLOAD
 
 logs/tempPackageDir/DBEHM.MORTGAGE.MAIN.REL.DBRM:
 total 16
-b binary      T=off -rw-r--r--   1 BPXROOT  TIVUSR       480 Oct 19 12:51 EPSCMORT.DBRM
+b binary      T=off -rw-r--r--   1 BPXROOT  TIVUSR       480 Dec 18 13:34 EPSCMORT.DBRM
 prepareLogs.sh: [INFO] tar -cf logs.tar logs
 prepareLogs.sh: [INFO] Logs successfully stored at /u/dbehm/backendWorkspace/MortApp/main/build-2/logs.tar
 USS file downloaded successfully.
@@ -1322,7 +1360,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-3 -r https://github.com/dennis-behm/MortgageApplication.git -b main"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/main/build-3
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -1330,6 +1368,7 @@ gitClone.sh: [INFO] **        Branch: main -> main
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch main to /u/dbehm/backendWorkspace/MortApp/main/build-3
+gitClone.sh: [INFO] git clone -b main https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch main
@@ -1340,9 +1379,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/heads/main
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -1353,7 +1392,7 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-3 -a MortgageApplication -b main  -p preview"
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-3
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: main
@@ -1372,10 +1411,12 @@ dbbBuild.sh: [INFO] ************************************************************
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
 dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/main/build-3 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/main/build-3/logs --hlq DBEHM.MORTGAGE.MAIN.BLD --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0
 
-** Build start at 20231019.115211.052
+** Build start at 20231218.133503.606
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/main/build-3/logs
-** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231019.115211.052
+** Build result created for BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133503.606
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/main/build-3/logs/buildList.txt
 ** Writing list of deleted files to /u/dbehm/backendWorkspace/MortApp/main/build-3/logs/deletedFilesList.txt
@@ -1384,13 +1425,14 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 ** Building 2 files mapped to Cobol.groovy script
 *** (1/2) Building file MortgageApplication/cobol/epsnbrvl.cbl
 *** (2/2) Building file MortgageApplication/cobol/epscmort.cbl
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/main/build-3/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/main/build-3/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231019.115211.052
-** Build ended at Thu Oct 19 11:52:17 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-main BuildLabel:build.20231218.133503.606
+** Build ended at Mon Dec 18 13:35:10 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 2
-** Total build time  : 5.979 seconds
+** Total build time  : 6.637 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/main/build-3/logs/buildList.txt
@@ -1401,7 +1443,7 @@ Pull Logs
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && prepareLogs.sh -w /u/dbehm/backendWorkspace/MortApp/main/build-3"
 prepareLogs.sh: [INFO] Prepare Build logs script. Version=1.00
 prepareLogs.sh: [INFO] **************************************************************
-prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 prepareLogs.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/main/build-3
 prepareLogs.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/main/build-3/logs
 prepareLogs.sh: [INFO] **************************************************************
@@ -1409,12 +1451,12 @@ prepareLogs.sh: [INFO] **  Directory contents:
 prepareLogs.sh: [INFO] ls -RlTr logs
 logs:
 total 240
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Oct 19 12:52 deletedFilesList.txt
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        78 Oct 19 12:52 buildList.txt
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Oct 19 12:52 EPSNBRVL.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53985 Oct 19 12:52 EPSCMORT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Oct 19 12:52 BuildReport.json
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      7861 Oct 19 12:52 BuildReport.html
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Dec 18 13:35 deletedFilesList.txt
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        78 Dec 18 13:35 buildList.txt
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18413 Dec 18 13:35 EPSNBRVL.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     53977 Dec 18 13:35 EPSCMORT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      9098 Dec 18 13:35 BuildReport.json
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      7861 Dec 18 13:35 BuildReport.html
 prepareLogs.sh: [INFO] tar -cf logs.tar logs
 prepareLogs.sh: [INFO] Logs successfully stored at /u/dbehm/backendWorkspace/MortApp/main/build-3/logs.tar
 USS file downloaded successfully.
@@ -1426,7 +1468,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b feature/setmainbuildbranch"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -1434,6 +1476,7 @@ gitClone.sh: [INFO] **        Branch: feature/setmainbuildbranch -> feature/setm
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch feature/setmainbuildbranch to /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1
+gitClone.sh: [INFO] git clone -b feature/setmainbuildbranch https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch feature/setmainbuildbranch
@@ -1444,9 +1487,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/heads/feature/setmainbuildbranch
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -1457,13 +1500,14 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1 -a MortgageApplication -b feature/setmainbuildbranch "
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] Set default Pipeline Type : build .
+setmainbuildbranch
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: feature/setmainbuildbranch
 dbbBuild.sh: [INFO] **         Build Type: --impactBuild --debug
-dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.FEATURE.SETMAINB
+dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.FSETMAIN
 dbbBuild.sh: [INFO] **             AppDir: /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/MortgageApplication
 dbbBuild.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs
 dbbBuild.sh: [INFO] **     zAppBuild Path: /var/dbb/dbb-zappbuild_300
@@ -1475,23 +1519,26 @@ dbbBuild.sh: [INFO] **         DBB Logger: No
 dbbBuild.sh: [INFO] **************************************************************
 
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
-dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs --hlq DBEHM.MORTGAGE.FEATURE.SETMAINB --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --debug
+dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs --hlq DBEHM.MORTGAGE.FSETMAIN --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --debug
 
-** Build start at 20231019.115235.052
+** Build start at 20231218.133539.452
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs
-** Build result created for BuildGroup:MortgageApplication-feature/setmainbuildbranch BuildLabel:build.20231019.115235.052
+** Build result created for BuildGroup:MortgageApplication-feature/setmainbuildbranch BuildLabel:build.20231218.133539.452
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs/buildList.txt
 ** Populating file level properties from individual artifact properties files.
 *! No files in build list.  Nothing to do.
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-feature/setmainbuildbranch BuildLabel:build.20231019.115235.052
-** Build ended at Thu Oct 19 11:52:37 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-feature/setmainbuildbranch BuildLabel:build.20231218.133539.452
+** Build ended at Mon Dec 18 13:35:40 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 0
-** Total build time  : 1.403 seconds
+** Total build time  : 1.442 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/feature/setmainbuildbranch/build-1/logs/buildList.txt
@@ -1507,7 +1554,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b release/rel-1.0.0"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -1515,6 +1562,7 @@ gitClone.sh: [INFO] **        Branch: release/rel-1.0.0 -> release/rel-1.0.0
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch release/rel-1.0.0 to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1
+gitClone.sh: [INFO] git clone -b release/rel-1.0.0 https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch release/rel-1.0.0
@@ -1525,9 +1573,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/heads/release/rel-1.0.0
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -1538,13 +1586,14 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1 -a MortgageApplication -b release/rel-1.0.0 "
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] Set default Pipeline Type : build .
+rel-1.0.0
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: release/rel-1.0.0
 dbbBuild.sh: [INFO] **         Build Type: --impactBuild --baselineRef refs/tags/rel-1.0.0 --debug
-dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.RELEASE.REL100
+dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.R100
 dbbBuild.sh: [INFO] **             AppDir: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/MortgageApplication
 dbbBuild.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
 dbbBuild.sh: [INFO] **     zAppBuild Path: /var/dbb/dbb-zappbuild_300
@@ -1556,12 +1605,14 @@ dbbBuild.sh: [INFO] **         DBB Logger: No
 dbbBuild.sh: [INFO] **************************************************************
 
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
-dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs --hlq DBEHM.MORTGAGE.RELEASE.REL100 --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0 --debug
+dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs --hlq DBEHM.MORTGAGE.R100 --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0 --debug
 
-** Build start at 20231019.115254.052
+** Build start at 20231218.133603.843
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
-** Build result created for BuildGroup:MortgageApplication-release/rel-1.0.0 BuildLabel:build.20231019.115254.052
+** Build result created for BuildGroup:MortgageApplication-release/rel-1.0.0 BuildLabel:build.20231218.133603.843
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/buildList.txt
 ** Writing list of deleted files to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/deletedFilesList.txt
@@ -1573,13 +1624,14 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 *** (1/3) Building file MortgageApplication/cobol/epsnbrvl.cbl
 *** (2/3) Building file MortgageApplication/cobol/epscmort.cbl
 *** (3/3) Building file MortgageApplication/cobol/epscsmrt.cbl
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-release/rel-1.0.0 BuildLabel:build.20231019.115254.052
-** Build ended at Thu Oct 19 11:53:03 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-release/rel-1.0.0 BuildLabel:build.20231218.133603.843
+** Build ended at Mon Dec 18 13:36:13 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 4
-** Total build time  : 9.490 seconds
+** Total build time  : 9.864 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/buildList.txt
@@ -1587,12 +1639,12 @@ dbbBuild.sh: [INFO] DBB Build Complete. rc=0
 rc=0
 Package Step - UCD Packaging
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1  -b release/rel-1.0.0 -u http://acme.pipeline.org/MortgageApplication.rel-1.0.0.fix-1.build-1 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1  -b release/rel-1.0.0 -u http://acme.pipeline.org/MortgageApplication.rel-1.0.0.fix-1.build-1 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
 ucdPackaging.sh: [INFO] UCD Packaging Wrapper. Version=1.00
 ucdPackaging.sh: [INFO] **************************************************************
-ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 ucdPackaging.sh: [INFO] **                 WorkDir:
-ucdPackaging.sh: [INFO] **             UCD Version: MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39
+ucdPackaging.sh: [INFO] **             UCD Version: MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43
 ucdPackaging.sh: [INFO] **           UCD Component: MortgageApplication
 ucdPackaging.sh: [INFO] **      Artifacts Location: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
 ucdPackaging.sh: [INFO] **    PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -1606,43 +1658,43 @@ ucdPackaging.sh: [INFO] **                DBB_HOME: /usr/lpp/dbb/v2r0
 ucdPackaging.sh: [INFO] **************************************************************
 
 ucdPackaging.sh: [INFO] Invoking the DBB UCD Packaging script.
-ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs --component MortgageApplication --versionName MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/MortgageApplication.rel-1.0.0.fix-1.build-1
-** Create version start at 20231019.115312.053
+ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs --component MortgageApplication --versionName MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/MortgageApplication.rel-1.0.0.fix-1.build-1
+** Create version start at 20231218.013626.036
 ** Properties at startup:
    preview -> false
    component -> MortgageApplication
    buztoolPath -> /var/ucd-agent/bin/buztool.sh
    buztoolPropertyFile -> /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json]
-   startTime -> 20231019.115312.053
+   startTime -> 20231218.013626.036
    workDir -> /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
-   versionName -> MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39
+   versionName -> MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43
    pipelineURL -> http://acme.pipeline.org/MortgageApplication.rel-1.0.0.fix-1.build-1
    ucdV2PackageFormat -> false
 * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 2.0.1.
 **  Reading provided build report(s).
 *** Parsing DBB build report /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json.
-**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json
-   DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSMORT), MAPLOAD
-   DBEHM.MORTGAGE.RELEASE.REL100.DBRM(EPSCMORT), DBRM
-   DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCMORT), CICSLOAD
-   DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCSMRT), CICSLOAD
+**  Deployable dataset members detected in /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json
+   DBEHM.MORTGAGE.R100.LOAD(EPSMORT), MAPLOAD
+   DBEHM.MORTGAGE.R100.DBRM(EPSCMORT), DBRM
+   DBEHM.MORTGAGE.R100.LOAD(EPSCMORT), CICSLOAD
+   DBEHM.MORTGAGE.R100.LOAD(EPSCSMRT), CICSLOAD
 ** Generate UCD ship list file
    Creating general UCD component version properties.
    Storing DBB Build result properties as general component version properties due to single build report.
-   Creating shiplist record for build output DBEHM.MORTGAGE.RELEASE.REL100.DBRM(EPSCMORT) with recordType EXECUTE.
-   Creating shiplist record for build output DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCMORT) with recordType EXECUTE.
-   Creating shiplist record for build output DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSMORT) with recordType EXECUTE.
-   Creating shiplist record for build output DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCSMRT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.R100.DBRM(EPSCMORT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.R100.LOAD(EPSCMORT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.R100.LOAD(EPSMORT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.R100.LOAD(EPSCSMRT) with recordType EXECUTE.
 ** Write ship list file to  /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/shiplist.xml
 ** Following UCD buztool cmd will be invoked
-/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39" 
+/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43" 
 ** Create version by running UCD buztool
 ....Command : createzosversion
 Reading inputs from passed arguments:
 ....Component : MortgageApplication
 ....Shiplist file : /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/shiplist.xml
-....Version name : MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39
+....Version name : MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43
 ....Output File Path : /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/buztool.output
 ....Buztool Properties file : /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
 ....Reading inputs from properties file /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
@@ -1651,49 +1703,48 @@ zOS toolkit config   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit binary   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit data set : RATCFG.UCD.V7R3M2 (7.3.2.0,20230525-0827)
 Verifying version
-....Repository location : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39
+....Repository location : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43
 Pre-processing shiplist:
-....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39/shiplist.xml
+....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43/shiplist.xml
 Packaging data sets:
-....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-1
-9_12-52-39
+....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-1
+8_13-35-43
 ....Zip name : package.zip
-....DBEHM.MORTGAGE.RELEASE.REL100.DBRM.bin
-....DBEHM.MORTGAGE.RELEASE.REL100.LOAD.bin
-....Elapsed time for data set package or deploy operation : 0.868245 seconds.
+....DBEHM.MORTGAGE.R100.DBRM.bin
+....DBEHM.MORTGAGE.R100.LOAD.bin
+....Elapsed time for data set package or deploy operation : 0.723957 seconds.
 Post-processing package:
 PackageManifest file post-processing completed. 
 Create version and store package in external repository:
 ....Uploading artifacts to ARTIFACTORY
-....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39.zip HTTP/1.1
+....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43.zip HTTP/1.1
 ....Version artifacts stored in External Repository server
-Elapsed time: 3.804 seconds.
+Elapsed time: 4.508 seconds.
 
 ** buztool output properties
    component.name -> MortgageApplication
    version.shiplist -> /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/shiplist.xml
-   version.url -> https://10.3.20.96:8443/#version/077abb24-5e88-4fc5-a1a7-b47d6fe351c0
-   version.id -> 077abb24-5e88-4fc5-a1a7-b47d6fe351c0
+   version.url -> https://10.3.20.96:8443/#version/f8969b5f-bcbb-40f9-b4f5-d585ee3f32e7
+   version.id -> f8969b5f-bcbb-40f9-b4f5-d585ee3f32e7
    version.repository.type -> EXTERNAL REPOSITORY
-   version.name -> MortgageApplication.rel-1.0.0.fix-1.build-1.2023-10-19_12-52-39
+   version.name -> MortgageApplication.rel-1.0.0.fix-1.build-1.2023-12-18_13-35-43
 ** Build finished
 ucdPackaging.sh: [INFO] DBB UCD Packaging Complete. rc=0
 rc=0
 Package Step - PackageBuildOutputs
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1 -a MortgageApplication -t package.tar -b release/rel-1.0.0 -u -v MortgageApplication.2023-10-19_12-52-39"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1 -a MortgageApplication -t package.tar -b release/rel-1.0.0 -u -v MortgageApplication.2023-12-18_13-35-43"
 packageBuildOutputs.sh: [INFO] Package Build Outputs wrapper. Version=1.00
 packageBuildOutputs.sh: [INFO] **************************************************************
-packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 packageBuildOutputs.sh: [INFO] **                  WorkDir: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1
 packageBuildOutputs.sh: [INFO] **              Application: MortgageApplication
 packageBuildOutputs.sh: [INFO] **                   Branch: release/rel-1.0.0
 packageBuildOutputs.sh: [INFO] **            Tar file Name: package.tar
 packageBuildOutputs.sh: [INFO] **     BuildReport Location: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
 packageBuildOutputs.sh: [INFO] **     PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
-packageBuildOutputs.sh: [INFO] **     Packaging properties: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
 packageBuildOutputs.sh: [INFO] ** Publish to Artifact Repo: true
-packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-10-19_12-52-39
+packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-12-18_13-35-43
 packageBuildOutputs.sh: [INFO] **         ArtifactRepo Url: http://10.3.20.231:8081/artifactory
 packageBuildOutputs.sh: [INFO] **        ArtifactRepo User: admin
 packageBuildOutputs.sh: [INFO] **    ArtifactRepo Password: xxxxx
@@ -1703,8 +1754,8 @@ packageBuildOutputs.sh: [INFO] **                 DBB_HOME: /usr/lpp/dbb/v2r0
 packageBuildOutputs.sh: [INFO] **************************************************************
 
 packageBuildOutputs.sh: [INFO] Invoking the Package Build Outputs script.
-packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs --tarFileName package.tar --packagingPropertiesFile /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-10-19_12-52-39 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory release/rel-1.0.0
-** PackageBuildOutputs start at 20231019.115327.053
+packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs --tarFileName package.tar --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-12-18_13-35-43 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory release/rel-1.0.0
+** PackageBuildOutputs start at 20231218.013644.036
 ** Properties at startup:
    addExtension -> true
    artifactRepository.directory -> release/rel-1.0.0
@@ -1713,35 +1764,33 @@ packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/Packa
    artifactRepository.url -> http://10.3.20.231:8081/artifactory
    artifactRepository.user -> admin
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json]
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
-   packagingPropertiesFile -> /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+   packagingPropertiesFile -> /ZT01/var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
    publish -> true
-   startTime -> 20231019.115327.053
+   startTime -> 20231218.013644.036
    tarFileName -> package.tar
    verbose -> false
-   versionName -> MortgageApplication.2023-10-19_12-52-39
+   versionName -> MortgageApplication.2023-12-18_13-35-43
    workDir -> /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
-** Read build report data from /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE 
-** Files detected in /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json
-   DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSMORT), MAPLOAD
-   DBEHM.MORTGAGE.RELEASE.REL100.DBRM(EPSCMORT), DBRM
-   DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCMORT), CICSLOAD
-   DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCSMRT), CICSLOAD
+** Read build report data from /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json.
+** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE...
+**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json
+   DBEHM.MORTGAGE.R100.LOAD(EPSMORT), MAPLOAD
+   DBEHM.MORTGAGE.R100.DBRM(EPSCMORT), DBRM
+   DBEHM.MORTGAGE.R100.LOAD(EPSCMORT), CICSLOAD
+   DBEHM.MORTGAGE.R100.LOAD(EPSCSMRT), CICSLOAD
 *** Number of build outputs to package: 4
-** Copying BuildOutputs to temporary package dir.
-     Copying DBEHM.MORTGAGE.RELEASE.REL100.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.RELEASE.REL100.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY
-     Copying DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.RELEASE.REL100.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD
-     Copying DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSMORT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.RELEASE.REL100.LOAD/EPSMORT.MAPLOAD with DBB Copymode LOAD
-     Copying DBEHM.MORTGAGE.RELEASE.REL100.LOAD(EPSCSMRT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.RELEASE.REL100.LOAD/EPSCSMRT.CICSLOAD with DBB Copymode LOAD
-** Copying /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/BuildReport.json to temporary package dir as BuildReport.json.
-** Copying /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar.
+** Copying build outputs to temporary package directory....
+     Copying DBEHM.MORTGAGE.R100.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.R100.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD...
+     Copying DBEHM.MORTGAGE.R100.LOAD(EPSMORT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.R100.LOAD/EPSMORT.MAPLOAD with DBB Copymode LOAD...
+     Copying DBEHM.MORTGAGE.R100.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.R100.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY...
+     Copying DBEHM.MORTGAGE.R100.LOAD(EPSCSMRT) to /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.R100.LOAD/EPSCSMRT.CICSLOAD with DBB Copymode LOAD...
+** Creating tar file at /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar...
 ** Package successfully created at /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar.
-** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/release/rel-1.0.0/MortgageApplication.2023-10-19_12-52-39/package.tar.
-** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/release/rel-1.0.0/MortgageApplication.2023-10-19_12-52-39/package.tar
-** Uploading /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/release/rel-1.0.0/MortgageApplication.2023-10-19_12-52-39/package.tar
-** Upload completed
+** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/release/rel-1.0.0/MortgageApplication.2023-12-18_13-35-43/package.tar...
+** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/release/rel-1.0.0/MortgageApplication.2023-12-18_13-35-43/package.tar
+** Uploading /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/release/rel-1.0.0/MortgageApplication.2023-12-18_13-35-43/package.tar...
+** Upload completed.
 ** Build finished
 packageBuildOutputs.sh: [INFO] Package Build Outputs Complete. rc=0
 rc=0
@@ -1750,7 +1799,7 @@ Pull Logs
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && prepareLogs.sh -w /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1"
 prepareLogs.sh: [INFO] Prepare Build logs script. Version=1.00
 prepareLogs.sh: [INFO] **************************************************************
-prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+prepareLogs.sh: [INFO] ** Started - Prepare logs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 prepareLogs.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1
 prepareLogs.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs
 prepareLogs.sh: [INFO] **************************************************************
@@ -1758,36 +1807,36 @@ prepareLogs.sh: [INFO] **  Directory contents:
 prepareLogs.sh: [INFO] ls -RlTr logs
 logs:
 total 720
-                    drwxr-xr-x   4 BPXROOT  TIVUSR      8192 Oct 19 12:53 tempPackageDir
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      4728 Oct 19 12:53 shiplist.xml
-m IBM-1047    T=off -rw-r--r--   1 BPXROOT  TIVUSR    161280 Oct 19 12:53 package.tar
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Oct 19 12:52 deletedFilesList.txt
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       469 Oct 19 12:53 buztool.output
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       153 Oct 19 12:52 buildList.txt
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18444 Oct 19 12:52 EPSNBRVL.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      4160 Oct 19 12:52 EPSMORT.bms.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     24077 Oct 19 12:53 EPSCSMRT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     59676 Oct 19 12:53 EPSCMORT.cobol.log
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     16197 Oct 19 12:53 BuildReport.json
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     14581 Oct 19 12:53 BuildReport.html
+                    drwxr-xr-x   4 BPXROOT  TIVUSR      8192 Dec 18 13:36 tempPackageDir
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR      4638 Dec 18 13:36 shiplist.xml
+m IBM-1047    T=off -rw-r--r--   1 BPXROOT  TIVUSR    161280 Dec 18 13:36 package.tar
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        53 Dec 18 13:36 deletedFilesList.txt
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       468 Dec 18 13:36 buztool.output
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR       153 Dec 18 13:36 buildList.txt
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     18444 Dec 18 13:36 EPSNBRVL.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR      4148 Dec 18 13:36 EPSMORT.bms.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     24055 Dec 18 13:36 EPSCSMRT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     59638 Dec 18 13:36 EPSCMORT.cobol.log
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     15847 Dec 18 13:36 BuildReport.json
+t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     14431 Dec 18 13:36 BuildReport.html
 
 logs/tempPackageDir:
-total 82
-t IBM-1047    T=on  -rw-r--r--   1 BPXROOT  TIVUSR      1015 Oct 19 12:53 packageBuildOutputs.properties
-- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        17 Oct 19 12:53 buildReportOrder.txt
-                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Oct 19 12:53 DBEHM.MORTGAGE.RELEASE.REL100.LOAD
-                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Oct 19 12:53 DBEHM.MORTGAGE.RELEASE.REL100.DBRM
-t UTF-8       T=on  -rw-r--r--   1 BPXROOT  TIVUSR     16197 Oct 19 12:53 BuildReport.json
+total 96
+- untagged    T=off -rw-r--r--   1 BPXROOT  ZSECURE     1038 Nov 29 12:32 packageBuildOutputs.properties
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR        97 Dec 18 13:36 buildReportOrder.txt
+                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Dec 18 13:36 DBEHM.MORTGAGE.R100.LOAD
+                    drwxr-xr-x   2 BPXROOT  TIVUSR      8192 Dec 18 13:36 DBEHM.MORTGAGE.R100.DBRM
+- untagged    T=off -rw-r--r--   1 BPXROOT  TIVUSR     15847 Dec 18 13:36 BuildReport.json
 
-logs/tempPackageDir/DBEHM.MORTGAGE.RELEASE.REL100.LOAD:
+logs/tempPackageDir/DBEHM.MORTGAGE.R100.LOAD:
 total 256
-- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR      4096 Oct 19 12:53 EPSMORT.MAPLOAD
-- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     36864 Oct 19 12:53 EPSCSMRT.CICSLOAD
-- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     69632 Oct 19 12:53 EPSCMORT.CICSLOAD
+- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR      4096 Dec 18 13:36 EPSMORT.MAPLOAD
+- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     36864 Dec 18 13:36 EPSCSMRT.CICSLOAD
+- untagged    T=off -rwxr-xr-x   1 BPXROOT  TIVUSR     69632 Dec 18 13:36 EPSCMORT.CICSLOAD
 
-logs/tempPackageDir/DBEHM.MORTGAGE.RELEASE.REL100.DBRM:
+logs/tempPackageDir/DBEHM.MORTGAGE.R100.DBRM:
 total 16
-b binary      T=off -rw-r--r--   1 BPXROOT  TIVUSR       480 Oct 19 12:53 EPSCMORT.DBRM
+b binary      T=off -rw-r--r--   1 BPXROOT  TIVUSR       480 Dec 18 13:36 EPSCMORT.DBRM
 prepareLogs.sh: [INFO] tar -cf logs.tar logs
 prepareLogs.sh: [INFO] Logs successfully stored at /u/dbehm/backendWorkspace/MortApp/release/rel-1.0.0/build-1/logs.tar
 USS file downloaded successfully.
@@ -1799,7 +1848,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b hotfix/rel-1.0.0/myfix"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -1807,6 +1856,7 @@ gitClone.sh: [INFO] **        Branch: hotfix/rel-1.0.0/myfix -> hotfix/rel-1.0.0
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch hotfix/rel-1.0.0/myfix to /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1
+gitClone.sh: [INFO] git clone -b hotfix/rel-1.0.0/myfix https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch hotfix/rel-1.0.0/myfix
@@ -1817,9 +1867,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/heads/hotfix/rel-1.0.0/myfix
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -1830,14 +1880,16 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1 -a MortgageApplication -b hotfix/rel-1.0.0/myfix "
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] Set default Pipeline Type : build .
+rel-1.0.0
+myfix
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: hotfix/rel-1.0.0/myfix
 dbbBuild.sh: [INFO] **         Build Type: --impactBuild
 dbbBuild.sh: [INFO] ** Property Override : mainBuildBranch=release/rel-1.0.0
-dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.HOTFIX.REL100.MYFIX
+dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.R100.HMYFIX
 dbbBuild.sh: [INFO] **             AppDir: /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/MortgageApplication
 dbbBuild.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs
 dbbBuild.sh: [INFO] **     zAppBuild Path: /var/dbb/dbb-zappbuild_300
@@ -1849,23 +1901,26 @@ dbbBuild.sh: [INFO] **         DBB Logger: No
 dbbBuild.sh: [INFO] **************************************************************
 
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
-dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs --hlq DBEHM.MORTGAGE.HOTFIX.REL100.MYFIX --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --propOverwrites mainBuildBranch=release/rel-1.0.0 --impactBuild
+dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs --hlq DBEHM.MORTGAGE.R100.HMYFIX --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --propOverwrites mainBuildBranch=release/rel-1.0.0 --impactBuild
 
-** Build start at 20231019.115352.053
+** Build start at 20231218.133717.828
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs
-** Build result created for BuildGroup:MortgageApplication-hotfix/rel-1.0.0/myfix BuildLabel:build.20231019.115352.053
+** Build result created for BuildGroup:MortgageApplication-hotfix/rel-1.0.0/myfix BuildLabel:build.20231218.133717.828
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs/buildList.txt
 ** Populating file level properties from individual artifact properties files.
 *! No files in build list.  Nothing to do.
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-hotfix/rel-1.0.0/myfix BuildLabel:build.20231019.115352.053
-** Build ended at Thu Oct 19 11:53:53 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-hotfix/rel-1.0.0/myfix BuildLabel:build.20231218.133717.828
+** Build ended at Mon Dec 18 13:37:19 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 0
-** Total build time  : 1.420 seconds
+** Total build time  : 2.074 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/hotfix/rel-1.0.0/myfix/build-1/logs/buildList.txt
@@ -1881,7 +1936,7 @@ cloneApplicationRepository
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b epic/implementAI"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
 gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
@@ -1889,6 +1944,7 @@ gitClone.sh: [INFO] **        Branch: epic/implementAI -> epic/implementAI
 gitClone.sh: [INFO] **************************************************************
 
 gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch epic/implementAI to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1
+gitClone.sh: [INFO] git clone -b epic/implementAI https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
 On branch epic/implementAI
@@ -1899,9 +1955,9 @@ gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/heads/epic/implementAI
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -1912,13 +1968,14 @@ Perform Build
 testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1 -a MortgageApplication -b epic/implementAI "
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] Set default Pipeline Type : build .
+implementAI
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
 dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
 dbbBuild.sh: [INFO] **             Branch: epic/implementAI
 dbbBuild.sh: [INFO] **         Build Type: --impactBuild --baselineRef refs/tags/rel-1.0.0 --debug
-dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.EPIC.IMPLEMEN
+dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.EIMPLEME
 dbbBuild.sh: [INFO] **             AppDir: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/MortgageApplication
 dbbBuild.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs
 dbbBuild.sh: [INFO] **     zAppBuild Path: /var/dbb/dbb-zappbuild_300
@@ -1930,12 +1987,14 @@ dbbBuild.sh: [INFO] **         DBB Logger: No
 dbbBuild.sh: [INFO] **************************************************************
 
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
-dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs --hlq DBEHM.MORTGAGE.EPIC.IMPLEMEN --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0 --debug
+dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs --hlq DBEHM.MORTGAGE.EIMPLEME --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --impactBuild --baselineRef refs/tags/rel-1.0.0 --debug
 
-** Build start at 20231019.115409.054
+** Build start at 20231218.133743.407
+**************** Initialization of the build process ****************
 ** Build output located at /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs
-** Build result created for BuildGroup:MortgageApplication-epic/implementAI BuildLabel:build.20231019.115409.054
+** Build result created for BuildGroup:MortgageApplication-epic/implementAI BuildLabel:build.20231218.133743.407
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
 ** Writing build list file to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/buildList.txt
 ** Writing list of deleted files to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/deletedFilesList.txt
@@ -1944,13 +2003,14 @@ dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/bu
 ** Building 2 files mapped to Cobol.groovy script
 *** (1/2) Building file MortgageApplication/cobol/epsnbrvl.cbl
 *** (2/2) Building file MortgageApplication/cobol/epscmort.cbl
+***************** Finalization of the build process *****************
 ** Writing build report data to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json
 ** Writing build report to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-epic/implementAI BuildLabel:build.20231019.115409.054
-** Build ended at Thu Oct 19 11:54:16 GMT+01:00 2023
+** Updating build result BuildGroup:MortgageApplication-epic/implementAI BuildLabel:build.20231218.133743.407
+** Build ended at Mon Dec 18 13:37:51 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 2
-** Total build time  : 6.640 seconds
+** Total build time  : 7.730 seconds
 
 ** Build finished
 dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/buildList.txt
@@ -1958,12 +2018,12 @@ dbbBuild.sh: [INFO] DBB Build Complete. rc=0
 rc=0
 Package Step - UCD Packaging
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1  -b epic/implementAI -u http://acme.pipeline.org/prelim_MortgageApplication.epic.implementAI.build-1 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && ucdPackaging.sh -v prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22 -c MortgageApplication -w /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1  -b epic/implementAI -u http://acme.pipeline.org/prelim_MortgageApplication.epic.implementAI.build-1 -e /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties"
 ucdPackaging.sh: [INFO] UCD Packaging Wrapper. Version=1.00
 ucdPackaging.sh: [INFO] **************************************************************
-ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+ucdPackaging.sh: [INFO] ** Started - UCD Publish on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 ucdPackaging.sh: [INFO] **                 WorkDir:
-ucdPackaging.sh: [INFO] **             UCD Version: prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56
+ucdPackaging.sh: [INFO] **             UCD Version: prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22
 ucdPackaging.sh: [INFO] **           UCD Component: MortgageApplication
 ucdPackaging.sh: [INFO] **      Artifacts Location: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs
 ucdPackaging.sh: [INFO] **    PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -1977,39 +2037,39 @@ ucdPackaging.sh: [INFO] **                DBB_HOME: /usr/lpp/dbb/v2r0
 ucdPackaging.sh: [INFO] **************************************************************
 
 ucdPackaging.sh: [INFO] Invoking the DBB UCD Packaging script.
-ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs --component MortgageApplication --versionName prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/prelim_MortgageApplication.epic.implementAI.build-1
-** Create version start at 20231019.120308.003
+ucdPackaging.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy --buztool /var/ucd-agent/bin/buztool.sh --workDir /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs --component MortgageApplication --versionName prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22 --propertyFile /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties --pipelineURL http://acme.pipeline.org/prelim_MortgageApplication.epic.implementAI.build-1
+** Create version start at 20231218.013803.038
 ** Properties at startup:
    preview -> false
    component -> MortgageApplication
    buztoolPath -> /var/ucd-agent/bin/buztool.sh
    buztoolPropertyFile -> /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json]
-   startTime -> 20231019.120308.003
+   startTime -> 20231218.013803.038
    workDir -> /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs
-   versionName -> prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56
+   versionName -> prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22
    pipelineURL -> http://acme.pipeline.org/prelim_MortgageApplication.epic.implementAI.build-1
    ucdV2PackageFormat -> false
 * Buildrecord type TYPE_COPY_TO_PDS is supported with DBB toolkit 1.0.8 and higher. Extracting build records for TYPE_COPY_TO_PDS might not be available and skipped. Identified DBB Toolkit version 2.0.1.
 **  Reading provided build report(s).
 *** Parsing DBB build report /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json.
-**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json
-   DBEHM.MORTGAGE.EPIC.IMPLEMEN.DBRM(EPSCMORT), DBRM
-   DBEHM.MORTGAGE.EPIC.IMPLEMEN.LOAD(EPSCMORT), CICSLOAD
+**  Deployable dataset members detected in /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json
+   DBEHM.MORTGAGE.EIMPLEME.DBRM(EPSCMORT), DBRM
+   DBEHM.MORTGAGE.EIMPLEME.LOAD(EPSCMORT), CICSLOAD
 ** Generate UCD ship list file
    Creating general UCD component version properties.
    Storing DBB Build result properties as general component version properties due to single build report.
-   Creating shiplist record for build output DBEHM.MORTGAGE.EPIC.IMPLEMEN.DBRM(EPSCMORT) with recordType EXECUTE.
-   Creating shiplist record for build output DBEHM.MORTGAGE.EPIC.IMPLEMEN.LOAD(EPSCMORT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.EIMPLEME.LOAD(EPSCMORT) with recordType EXECUTE.
+   Creating shiplist record for build output DBEHM.MORTGAGE.EIMPLEME.DBRM(EPSCMORT) with recordType EXECUTE.
 ** Write ship list file to  /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/shiplist.xml
 ** Following UCD buztool cmd will be invoked
-/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56" 
+/var/ucd-agent/bin/buztool.sh createzosversion -c MortgageApplication -s /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/shiplist.xml -o /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/buztool.output -prop /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties -v "prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22" 
 ** Create version by running UCD buztool
 ....Command : createzosversion
 Reading inputs from passed arguments:
 ....Component : MortgageApplication
 ....Shiplist file : /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/shiplist.xml
-....Version name : prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56
+....Version name : prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22
 ....Output File Path : /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/buztool.output
 ....Buztool Properties file : /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
 ....Reading inputs from properties file /var/jenkins/zappbuild_config/MortgageAppArtifactRepository.properties
@@ -2018,49 +2078,48 @@ zOS toolkit config   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit binary   : /var/ucd-agent/ (7.3.2.0,20230525-0827)
 zOS toolkit data set : RATCFG.UCD.V7R3M2 (7.3.2.0,20230525-0827)
 Verifying version
-....Repository location : /var/ucd-agent/var/repository/MortgageApplication/prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56
+....Repository location : /var/ucd-agent/var/repository/MortgageApplication/prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22
 Pre-processing shiplist:
-....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56/shiplist.xml
+....Shiplist after processing :/var/ucd-agent/var/repository/MortgageApplication/prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22/shiplist.xml
 Packaging data sets:
 ....Location to store zip : /var/ucd-agent/var/repository/MortgageApplication/prelim_MortgageApplication.epic.implementAI.build-1.2
-023-10-19_12-53-56
+023-12-18_13-37-22
 ....Zip name : package.zip
-....DBEHM.MORTGAGE.EPIC.IMPLEMEN.DBRM.bin
-....DBEHM.MORTGAGE.EPIC.IMPLEMEN.LOAD.bin
-....Elapsed time for data set package or deploy operation : 0.812655 seconds.
+....DBEHM.MORTGAGE.EIMPLEME.LOAD.bin
+....DBEHM.MORTGAGE.EIMPLEME.DBRM.bin
+....Elapsed time for data set package or deploy operation : 0.779674 seconds.
 Post-processing package:
 PackageManifest file post-processing completed. 
 Create version and store package in external repository:
 ....Uploading artifacts to ARTIFACTORY
-....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56.zip HTTP/1.1
+....Executing request PUT http://10.3.20.231:8081/artifactory/dbb-zos-mortgage-local/httpUpload/prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22.zip HTTP/1.1
 ....Version artifacts stored in External Repository server
-Elapsed time: 3.604 seconds.
+Elapsed time: 4.786 seconds.
 
 ** buztool output properties
    component.name -> MortgageApplication
    version.shiplist -> /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/shiplist.xml
-   version.url -> https://10.3.20.96:8443/#version/26698469-b57d-4558-9e74-275d1f31d219
-   version.id -> 26698469-b57d-4558-9e74-275d1f31d219
+   version.url -> https://10.3.20.96:8443/#version/17fb8294-67b9-4883-a753-34709d95482a
+   version.id -> 17fb8294-67b9-4883-a753-34709d95482a
    version.repository.type -> EXTERNAL REPOSITORY
-   version.name -> prelim_MortgageApplication.epic.implementAI.build-1.2023-10-19_12-53-56
+   version.name -> prelim_MortgageApplication.epic.implementAI.build-1.2023-12-18_13-37-22
 ** Build finished
 ucdPackaging.sh: [INFO] DBB UCD Packaging Complete. rc=0
 rc=0
 Package Step - PackageBuildOutputs
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1 -a MortgageApplication -t package.tar -b epic/implementAI -u -v MortgageApplication.2023-10-19_12-53-56"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && packageBuildOutputs.sh -w /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1 -a MortgageApplication -t package.tar -b epic/implementAI -u -v MortgageApplication.2023-12-18_13-37-22"
 packageBuildOutputs.sh: [INFO] Package Build Outputs wrapper. Version=1.00
 packageBuildOutputs.sh: [INFO] **************************************************************
-packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+packageBuildOutputs.sh: [INFO] ** Started - Package Build Outputs on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 packageBuildOutputs.sh: [INFO] **                  WorkDir: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1
 packageBuildOutputs.sh: [INFO] **              Application: MortgageApplication
 packageBuildOutputs.sh: [INFO] **                   Branch: epic/implementAI
 packageBuildOutputs.sh: [INFO] **            Tar file Name: package.tar
 packageBuildOutputs.sh: [INFO] **     BuildReport Location: /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs
 packageBuildOutputs.sh: [INFO] **     PackagingScript Path: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
-packageBuildOutputs.sh: [INFO] **     Packaging properties: /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
 packageBuildOutputs.sh: [INFO] ** Publish to Artifact Repo: true
-packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-10-19_12-53-56
+packageBuildOutputs.sh: [INFO] **            Artifact name: MortgageApplication.2023-12-18_13-37-22
 packageBuildOutputs.sh: [INFO] **         ArtifactRepo Url: http://10.3.20.231:8081/artifactory
 packageBuildOutputs.sh: [INFO] **        ArtifactRepo User: admin
 packageBuildOutputs.sh: [INFO] **    ArtifactRepo Password: xxxxx
@@ -2070,8 +2129,8 @@ packageBuildOutputs.sh: [INFO] **                 DBB_HOME: /usr/lpp/dbb/v2r0
 packageBuildOutputs.sh: [INFO] **************************************************************
 
 packageBuildOutputs.sh: [INFO] Invoking the Package Build Outputs script.
-packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs --tarFileName package.tar --packagingPropertiesFile /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-10-19_12-53-56 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory epic/implementAI
-** PackageBuildOutputs start at 20231019.120323.003
+packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs --tarFileName package.tar --addExtension --publish --artifactRepositoryUrl "http://10.3.20.231:8081/artifactory" --versionName MortgageApplication.2023-12-18_13-37-22 --artifactRepositoryUser admin --artifactRepositoryPassword artifactoryadmin --artifactRepositoryName MortgageApplication-repo-local --artifactRepositoryDirectory epic/implementAI
+** PackageBuildOutputs start at 20231218.013821.038
 ** Properties at startup:
    addExtension -> true
    artifactRepository.directory -> epic/implementAI
@@ -2080,61 +2139,60 @@ packageBuildOutputs.sh: [INFO] groovyz  /var/dbb/extensions/dbb20/Pipeline/Packa
    artifactRepository.url -> http://10.3.20.231:8081/artifactory
    artifactRepository.user -> admin
    buildReportOrder -> [/u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json]
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
-   packagingPropertiesFile -> /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+   packagingPropertiesFile -> /ZT01/var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
    publish -> true
-   startTime -> 20231019.120323.003
+   startTime -> 20231218.013821.038
    tarFileName -> package.tar
    verbose -> false
-   versionName -> MortgageApplication.2023-10-19_12-53-56
+   versionName -> MortgageApplication.2023-12-18_13-37-22
    workDir -> /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs
-** Read build report data from /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE 
-** Files detected in /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json
-   DBEHM.MORTGAGE.EPIC.IMPLEMEN.DBRM(EPSCMORT), DBRM
-   DBEHM.MORTGAGE.EPIC.IMPLEMEN.LOAD(EPSCMORT), CICSLOAD
+** Read build report data from /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json.
+** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE...
+**  Deployable files detected in /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json
+   DBEHM.MORTGAGE.EIMPLEME.DBRM(EPSCMORT), DBRM
+   DBEHM.MORTGAGE.EIMPLEME.LOAD(EPSCMORT), CICSLOAD
 *** Number of build outputs to package: 2
-** Copying BuildOutputs to temporary package dir.
-     Copying DBEHM.MORTGAGE.EPIC.IMPLEMEN.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.EPIC.IMPLEMEN.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY
-     Copying DBEHM.MORTGAGE.EPIC.IMPLEMEN.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.EPIC.IMPLEMEN.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD
-** Copying /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/BuildReport.json to temporary package dir as BuildReport.json.
-** Copying /var/dbb/extensions/dbb20/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar.
+** Copying build outputs to temporary package directory....
+     Copying DBEHM.MORTGAGE.EIMPLEME.LOAD(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.EIMPLEME.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD...
+     Copying DBEHM.MORTGAGE.EIMPLEME.DBRM(EPSCMORT) to /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/tempPackageDir/DBEHM.MORTGAGE.EIMPLEME.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY...
+** Creating tar file at /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar...
 ** Package successfully created at /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar.
-** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/epic/implementAI/MortgageApplication.2023-10-19_12-53-56/package.tar.
-** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/epic/implementAI/MortgageApplication.2023-10-19_12-53-56/package.tar
-** Uploading /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/epic/implementAI/MortgageApplication.2023-10-19_12-53-56/package.tar
-** Upload completed
+** Uploading package to Artifact Repository http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/epic/implementAI/MortgageApplication.2023-12-18_13-37-22/package.tar...
+** ArtifactRepositoryHelper started for upload of /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/epic/implementAI/MortgageApplication.2023-12-18_13-37-22/package.tar
+** Uploading /u/dbehm/backendWorkspace/MortApp/epic/implementAI/build-1/logs/package.tar to http://10.3.20.231:8081/artifactory/MortgageApplication-repo-local/epic/implementAI/MortgageApplication.2023-12-18_13-37-22/package.tar...
+** Upload completed.
 ** Build finished
 packageBuildOutputs.sh: [INFO] Package Build Outputs Complete. rc=0
 rc=0
 testGenericWrapper.sh: [TEST] Executing test scenario testMortgageApplication-Epic-Feature-implementAI-Build-1.
 cloneApplicationRepository
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b implementAI/myFeatureImpl"
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && gitClone.sh -w /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1 -r https://github.com/dennis-behm/MortgageApplication.git -b feature/implementAI/myFeatureImpl"
 gitClone.sh: [INFO] Git Clone Wrapper. Version=1.1.0
 gitClone.sh: [INFO] **************************************************************
-gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 04.00 02 8561/BPXROOT
+gitClone.sh: [INFO] ** Start Git Clone on HOST/USER: z/OS ZT01 05.00 02 8561/BPXROOT
 gitClone.sh: [INFO] **          Repo: https://github.com/dennis-behm/MortgageApplication.git
-gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1
+gitClone.sh: [INFO] **       WorkDir: /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1
 gitClone.sh: [INFO] **        GitDir: MortgageApplication
-gitClone.sh: [INFO] **        Branch: implementAI/myFeatureImpl -> implementAI/myFeatureImpl
+gitClone.sh: [INFO] **        Branch: feature/implementAI/myFeatureImpl -> feature/implementAI/myFeatureImpl
 gitClone.sh: [INFO] **************************************************************
 
-gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch implementAI/myFeatureImpl to /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1
+gitClone.sh: [INFO] Preforming Git Clone of Repo https://github.com/dennis-behm/MortgageApplication.git, Branch feature/implementAI/myFeatureImpl to /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1
+gitClone.sh: [INFO] git clone -b feature/implementAI/myFeatureImpl https://github.com/dennis-behm/MortgageApplication.git
 Cloning into 'MortgageApplication'...
 gitClone.sh: [INFO] Git Status for MortgageApplication
-On branch implementAI/myFeatureImpl
-Your branch is up to date with 'origin/implementAI/myFeatureImpl'.
+On branch feature/implementAI/myFeatureImpl
+Your branch is up to date with 'origin/feature/implementAI/myFeatureImpl'.
 
 nothing to commit, working tree clean
 gitClone.sh: [INFO] Git Show-Ref for MortgageApplication
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/heads/implementAI/myFeatureImpl
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/heads/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/HEAD
 a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/epic/implementAI
+a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/feature/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/feature/setmainbuildbranch
 f3050d7c6d38360eac5980411cd0483a7683adc9 refs/remotes/origin/hotfix/rel-1.0.0/myfix
-a411fc163a07c1e054c08e8c3bc055c8fd713fd2 refs/remotes/origin/implementAI/myFeatureImpl
 f7380c46a60e7614539ceb4da6d3aa0dd531a238 refs/remotes/origin/main
 c276d8fe3db4dce2e4183130a4feb7525bae4dfa refs/remotes/origin/release/rel-1.0.0
 0cc39e464cdd6fa7a4a7e9bb1381e25daf757d08 refs/tags/rel-1.0.0
@@ -2142,19 +2200,21 @@ gitClone.sh: [INFO] Clone Repository Complete. rc=0
 rc=0
 Perform Build
 -------------
-testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1 -a MortgageApplication -b implementAI/myFeatureImpl "
+testGenericWrapper.sh: [COMMAND] ssh dbehm@10.3.20.201 ". /u/dbehm/.profile && dbbBuild.sh -w /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1 -a MortgageApplication -b feature/implementAI/myFeatureImpl "
 dbbBuild.sh: [INFO] DBB Build Wrapper. Version=1.10
 dbbBuild.sh: [INFO] Set default Pipeline Type : build .
+implementAI
+myFeatureImpl
 dbbBuild.sh: [INFO] **************************************************************
-dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 04.00 02 8561/DBEHM
-dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1
+dbbBuild.sh: [INFO] ** Started - DBB Build on HOST/USER: z/OS ZT01 05.00 02 8561/DBEHM
+dbbBuild.sh: [INFO] **          Workspace: /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1
 dbbBuild.sh: [INFO] **        Application: MortgageApplication
-dbbBuild.sh: [INFO] **             Branch: implementAI/myFeatureImpl
+dbbBuild.sh: [INFO] **             Branch: feature/implementAI/myFeatureImpl
 dbbBuild.sh: [INFO] **         Build Type: --impactBuild --debug
 dbbBuild.sh: [INFO] ** Property Override : mainBuildBranch=epic/implementAI
-dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.IMPLEMEN.MYFEATUR
-dbbBuild.sh: [INFO] **             AppDir: /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/MortgageApplication
-dbbBuild.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs
+dbbBuild.sh: [INFO] **                HLQ: DBEHM.MORTGAGE.EIMPLEME.FMYFEATU
+dbbBuild.sh: [INFO] **             AppDir: /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/MortgageApplication
+dbbBuild.sh: [INFO] **             LogDir: /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs
 dbbBuild.sh: [INFO] **     zAppBuild Path: /var/dbb/dbb-zappbuild_300
 dbbBuild.sh: [INFO] **           DBB_HOME: /usr/lpp/dbb/v2r0
 dbbBuild.sh: [INFO] **      DBB JDBC USER: DBEHM
@@ -2164,26 +2224,29 @@ dbbBuild.sh: [INFO] **         DBB Logger: No
 dbbBuild.sh: [INFO] **************************************************************
 
 dbbBuild.sh: [INFO] Invoking the zAppBuild Build Framework.
-dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs --hlq DBEHM.MORTGAGE.IMPLEMEN.MYFEATUR --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --propOverwrites mainBuildBranch=epic/implementAI --impactBuild --debug
+dbbBuild.sh: [INFO] /usr/lpp/dbb/v2r0/bin/groovyz  /var/dbb/dbb-zappbuild_300/build.groovy --workspace /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1 --application MortgageApplication --outDir /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs --hlq DBEHM.MORTGAGE.EIMPLEME.FMYFEATU --id DBEHM --pwFile /var/dbb/config/db2-pwd-file.xml  --logEncoding UTF-8 --propFiles /var/dbb/dbb-zappbuild-config/build.properties,/var/dbb/dbb-zappbuild-config/datasets.properties,/var/dbb/dbb-zappbuild-config/buildFolder.properties --propOverwrites mainBuildBranch=epic/implementAI --impactBuild --debug
 
-** Build start at 20231019.120345.003
-** Build output located at /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs
-** Build result created for BuildGroup:MortgageApplication-implementAI/myFeatureImpl BuildLabel:build.20231019.120345.003
+** Build start at 20231218.133847.556
+**************** Initialization of the build process ****************
+** Build output located at /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs
+** Build result created for BuildGroup:MortgageApplication-feature/implementAI/myFeatureImpl BuildLabel:build.20231218.133847.556
 ** Loading DBB scanner mapping configuration dbb.scannerMapping
+************* Creation and processing of the build list *************
 ** --impactBuild option selected. Building impacted programs for application MortgageApplication 
-** Writing build list file to /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs/buildList.txt
+** Writing build list file to /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs/buildList.txt
 ** Populating file level properties from individual artifact properties files.
 *! No files in build list.  Nothing to do.
-** Writing build report data to /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs/BuildReport.json
-** Writing build report to /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs/BuildReport.html
-** Updating build result BuildGroup:MortgageApplication-implementAI/myFeatureImpl BuildLabel:build.20231019.120345.003
-** Build ended at Thu Oct 19 12:03:47 GMT+01:00 2023
+***************** Finalization of the build process *****************
+** Writing build report data to /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs/BuildReport.json
+** Writing build report to /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs/BuildReport.html
+** Updating build result BuildGroup:MortgageApplication-feature/implementAI/myFeatureImpl BuildLabel:build.20231218.133847.556
+** Build ended at Mon Dec 18 13:38:49 GMT+01:00 2023
 ** Build State : CLEAN
 ** Total files processed : 0
-** Total build time  : 1.383 seconds
+** Total build time  : 1.596 seconds
 
 ** Build finished
-dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/implementAI/myFeatureImpl/build-1/logs/buildList.txt
+dbbBuild.sh: [INFO} LastBuildLog = /u/dbehm/backendWorkspace/MortApp/feature/implementAI/myFeatureImpl/build-1/logs/buildList.txt
 dbbBuild.sh: [WARNING] DBB Build Error. No source changes detected. rc=4
 rc=4
 Pull Logs

--- a/Templates/Common-Backend-Scripts/test/testGenericWrapper.sh
+++ b/Templates/Common-Backend-Scripts/test/testGenericWrapper.sh
@@ -711,7 +711,7 @@ testMortgageApplication-Epic-implementAI-Build-1() {
 ############# MortgageApplication contibution to the next release
 testMortgageApplication-Epic-Feature-implementAI-Build-1() {
     echo "$PGM: [TEST] Executing test scenario testMortgageApplication-Epic-Feature-implementAI-Build-1."
-    branch="implementAI/myFeatureImpl"
+    branch="feature/implementAI/myFeatureImpl"
     uniqueWorkspaceId="MortApp/${branch}/build-1"
     ucdVersionName="prelim_${application}.epic.implementAI.build-1"
     # set timestamp

--- a/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
+++ b/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
@@ -2,6 +2,7 @@
 mainBranchSegment=""
 secondBranchSegment=""
 baselineReferenceFile=""
+segmentName=""
 
 computeBuildConfiguration() {
 
@@ -15,10 +16,10 @@ computeBuildConfiguration() {
     HLQ=$(echo ${HLQPrefix}.${App:0:8} | tr '[:lower:]' '[:upper:]' | tr -d '-')
 
     # Locate the baseline reference file based on the baselineReferenceLocation config in pipelineBackend.config
-    baselineReferenceFile="${AppDir}/$baselineReferenceLocation"
+    #baselineReferenceFile="${AppDir}/$baselineReferenceLocation"
 
     if [ ! -f "${baselineReferenceFile}" ]; then
-        rc=8
+        #rc=8
         ERRMSG=$PGM": [ERROR] Applications baseline reference configuration file (${baselineReferenceFile}) was not found. rc="$rc
         echo $ERRMSG
     fi
@@ -28,7 +29,7 @@ computeBuildConfiguration() {
     if [ $rc -eq 0 ]; then
         if [ ${#branchConvention[@]} -gt 3 ]; then
             rc=8
-            ERRMSG=$PGM": [ERROR] Script is only managing branch name with 3 segments (${Branch}) . rc="$rc
+            ERRMSG=$PGM": [ERROR] Script is only managing branch name with up to 3 segments (${Branch}) . rc="$rc
             echo $ERRMSG
         fi
     fi
@@ -42,15 +43,24 @@ computeBuildConfiguration() {
 
         # remove chars (. -) from the name
         mainBranchSegmentTrimmed=$(echo ${mainBranchSegment} | tr -d '.-' | tr '[:lower:]' '[:upper:]')
-        secondBranchSegmentTrimmed=$(echo ${secondBranchSegment} | tr -d '.-' | tr '[:lower:]' '[:upper:]')
-        thirdBranchSegmentTrimmed=$(echo ${thirdBranchSegment} | tr -d '.-' | tr '[:lower:]' '[:upper:]')
-
+        
         # evaluate main segment
         case $mainBranchSegmentTrimmed in
         REL* | EPIC* | PROJ*)
             # Release maintenance, epic and project branches are intergration branches,
             # that derive dependency information from mainBuildBranch configuration.
-            HLQ="${HLQ}.${mainBranchSegmentTrimmed:0:8}"
+
+            # evaluate third segment
+            if [ ! -z "${thirdBranchSegment}" ]; then
+                rc=8
+                ERRMSG=$PGM": [ERROR] Branch (${Branch}) does not follow standard naming conventions  . rc="$rc
+                echo $ERRMSG
+            else
+                # feature branches for next planned release
+                computeSegmentName $secondBranchSegment
+                HLQ="${HLQ}.${mainBranchSegmentTrimmed:0:1}${segmentName:0:7}"
+            fi
+
             getBaselineReference
             if [ -z "${Type}" ]; then
                 Type="--impactBuild"
@@ -62,7 +72,24 @@ computeBuildConfiguration() {
             fi
             ;;
         FEATURE*)
-            HLQ="${HLQ}.FEATURE"
+            # all feature branche start with F
+
+            # evaluate third segment
+            if [ ! -z "${thirdBranchSegment}" ]; then
+                # feature branches for EPIC workflow
+                computeSegmentName $secondBranchSegment
+                HLQ="${HLQ}.E${segmentName:0:7}"
+                computeSegmentName $thirdBranchSegment
+                HLQ="${HLQ}.F${segmentName:0:7}"
+                
+                propOverrides="mainBuildBranch=epic/${secondBranchSegment}"
+
+            else
+                # feature branches for next planned release
+                computeSegmentName $secondBranchSegment
+                HLQ="${HLQ}.F${segmentName:0:7}"
+            fi
+
             if [ -z "${Type}" ]; then
                 Type="--impactBuild"
                 # appending the --debug flag to compile with TEST options
@@ -70,7 +97,20 @@ computeBuildConfiguration() {
             fi
             ;;
         HOTFIX*)
-            HLQ="${HLQ}.HOTFIX"
+
+            # evaluate third segment
+            if [ ! -z "${thirdBranchSegment}" ]; then
+                # feature branches for hotfix workflow
+                computeSegmentName $secondBranchSegment
+                HLQ="${HLQ}.R${segmentName:0:7}"
+                computeSegmentName $thirdBranchSegment
+                HLQ="${HLQ}.H${segmentName:0:7}"
+            else
+                rc=8
+                ERRMSG=$PGM": [ERROR] Hotfix branch (${Branch}) does not follow naming conventions  . rc="$rc
+                echo $ERRMSG
+            fi
+
             if [ -z "${Type}" ]; then
                 Type="--impactBuild"
                 propOverrides="mainBuildBranch=release/${secondBranchSegment}"
@@ -92,7 +132,6 @@ computeBuildConfiguration() {
                 fi
             fi
 
-            #Type="--fullBuild" # init build environment
             ;;
         *)
             # Treat other branches as feature branch.
@@ -116,16 +155,6 @@ computeBuildConfiguration() {
             # ;;
         esac
 
-        # evaluate second segment
-        if [ ! -z "${secondBranchSegment}" ]; then
-            HLQ="${HLQ}.${secondBranchSegmentTrimmed:0:8}"
-        fi
-
-        # evaluate third segment
-        if [ ! -z "${thirdBranchSegment}" ]; then
-            HLQ="${HLQ}.${thirdBranchSegmentTrimmed:0:8}"
-        fi
-
         # append pipeline preview if specified
         if [ "${PipelineType}" == "preview" ]; then
             if [ -z "${Type}" ]; then
@@ -146,6 +175,7 @@ computeBuildConfiguration() {
         thirdBranchSegment=""
         thirdBranchSegmentTrimmed=""
         branchConvention=""
+        segmentName=""
 
     fi
 
@@ -164,4 +194,32 @@ getBaselineReference() {
     fi
 
     ##DEBUG ## echo -e "baselineRef \t: ${baselineRef}"    ## DEBUG
+}
+
+
+#
+# computation of branch segments
+# captured cases
+#
+# containing numbers, assuming to be an work-item-id
+# containing strings and words separated by dashes, return first characters of each string
+# none of the above - return segement name in upper case w/o underscores
+#
+
+computeSegmentName() {
+
+    segmentName=$1
+    echo $segmentName
+    if [ ! -z $(echo "$segmentName" | tr -dc '0-9') ]; then
+        # "contains numbers"
+        retval=$(echo "$segmentName" | tr -dc '0-9')
+    elif [[ $segmentName == *"-"* ]]; then
+        # contains dashes
+        segmentNameTrimmed=$(echo "$segmentName" | awk -F "-" '{ for(i=1; i <= NF;i++) print($i) }' | cut -c-1-1)
+        segment1=$(echo "$segmentNameTrimmed" | tr -d '\n')
+        retval=$(echo "$segment1" | tr '[:lower:]' '[:upper:]')
+    else 
+        retval=$(echo "$segmentName" | tr -d '_' | tr '[:lower:]' '[:upper:]')
+    fi
+    segmentName=$(echo "$retval")
 }

--- a/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
+++ b/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
@@ -77,8 +77,10 @@ computeBuildConfiguration() {
             # evaluate third segment
             if [ ! -z "${thirdBranchSegment}" ]; then
                 # feature branches for EPIC workflow
-                computeSegmentName $secondBranchSegment
-                HLQ="${HLQ}.E${segmentName:0:7}"
+                
+                # // skipped for simplicity
+                # computeSegmentName $secondBranchSegment
+                # HLQ="${HLQ}.E${segmentName:0:7}"
                 computeSegmentName $thirdBranchSegment
                 HLQ="${HLQ}.F${segmentName:0:7}"
                 
@@ -101,8 +103,10 @@ computeBuildConfiguration() {
             # evaluate third segment
             if [ ! -z "${thirdBranchSegment}" ]; then
                 # feature branches for hotfix workflow
-                computeSegmentName $secondBranchSegment
-                HLQ="${HLQ}.R${segmentName:0:7}"
+
+                # // skipped for simplicity
+                # computeSegmentName $secondBranchSegment
+                # HLQ="${HLQ}.R${segmentName:0:7}"
                 computeSegmentName $thirdBranchSegment
                 HLQ="${HLQ}.H${segmentName:0:7}"
             else

--- a/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
+++ b/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
@@ -16,10 +16,10 @@ computeBuildConfiguration() {
     HLQ=$(echo ${HLQPrefix}.${App:0:8} | tr '[:lower:]' '[:upper:]' | tr -d '-')
 
     # Locate the baseline reference file based on the baselineReferenceLocation config in pipelineBackend.config
-    #baselineReferenceFile="${AppDir}/$baselineReferenceLocation"
+    baselineReferenceFile="${AppDir}/$baselineReferenceLocation"
 
     if [ ! -f "${baselineReferenceFile}" ]; then
-        #rc=8
+        rc=8
         ERRMSG=$PGM": [ERROR] Applications baseline reference configuration file (${baselineReferenceFile}) was not found. rc="$rc
         echo $ERRMSG
     fi


### PR DESCRIPTION
As indicated in #193, the pipeline backend scripts need to use shorter branch names.

This PR is refreshing the computation of the build conventions:

* Feature branches are prefixed with an `F`.
* Epic branches are prefixed with `E`.
* Hotfix branches are prefixed with `H`.
* Release Maintenance branches are prefixed with `R`.

| branch name  | computed hlq | 
| -------------  | ------------ |
|feature/42-new-mortgage-calculation |PIPELINE.MORTGAGE.F42 |
|feature/new-mortgage-calculation |PIPELINE.MORTGAGE.FNMC |
|feature/newmortgagecalculation |PIPELINE.MORTGAGE.FNEWMORT |
|release/rel-2.0.1  | PIPELINE.MORTGAGE.R201 | 
|hotfix/rel-2.0.1/52-fix-mortgage-calculation |PIPELINE.MORTGAGE.R201.H52 |
|epic/ai-fraud-detection |PIPELINE.MORTGAGE.EAFD |
|feature/ai-fraud-detection/54-introduce-ai-model-to-mortgage-calculation |PIPELINE.MORTGAGE.EAFD.F54 |







