### PR TITLE
Common Backend Scripts - Enabling cumulative feature branch builds

### DIFF
--- a/Templates/Common-Backend-Scripts/pipelineBackend.config
+++ b/Templates/Common-Backend-Scripts/pipelineBackend.config
@@ -87,6 +87,12 @@ dbbMetadataStoreJdbcPwdFile=""
 #   metadataStoreDb2ConnectionConf property
 dbbMetadataStoreJdbcUrl=""
 
+# Feature branch build behaviour
+# options 
+# - "incremental" enables incremental builds for changed added to the feature branch
+# - "cumulative" enables cumulative builds with baselineRef option to build all contributed changes
+featureBranchBuildBehaviour=cumulative
+
 #####################################################################################################
 ## End of DBB-BUILD.sh parameters    ################################################################
 #####################################################################################################


### PR DESCRIPTION
Creating a cumulative package from the build pipeline for feature branches, is a desirable aspect of the development workflow, and would improve the workflow to [package and deploy a feature for testing in controlled test environments](https://ibm.github.io/z-devops-acceleration-program/docs/branching-model-supporting-pipeline#package-and-deploy-a-feature-for-testing-in-controlled-test-environments).

This PR lets the DevX team configure the common backend scripts and the behaviour of feature branch pipelines. 

The build phase of feature branch pipelines can be configured to always build all changes for the feature along with the impact build capability of DBB. This is the default build behaviour.

