### PR TITLE
Leverage DBB_HOME to resolve DBB toolkit in template scripts

### DIFF
--- a/Templates/Common-Backend-Scripts/packageBuildOutputs.sh
+++ b/Templates/Common-Backend-Scripts/packageBuildOutputs.sh
@@ -463,7 +463,7 @@ fi
 if [ $rc -eq 0 ]; then
     echo $PGM": [INFO] Invoking the Package Build Outputs script."
 
-    CMD="groovyz ${log4j2} ${PackagingScript} --workDir ${logDir}"
+    CMD="$DBB_HOME/bin/groovyz ${log4j2} ${PackagingScript} --workDir ${logDir}"
 
     # add tarfile name
     if [ ! -z "${tarFileName}" ]; then

--- a/Templates/Common-Backend-Scripts/ucdPackaging.sh
+++ b/Templates/Common-Backend-Scripts/ucdPackaging.sh
@@ -398,7 +398,7 @@ fi
 if [ $rc -eq 0 ]; then
     echo $PGM": [INFO] Invoking the DBB UCD Packaging script."
 
-    CMD="groovyz ${log4j2} ${ucdPackagingScript} --buztool ${BuzTool} --workDir ${logDir} --component ${UcdComp} --versionName ${UcdVers}"
+    CMD="$DBB_HOME/bin/groovyz ${log4j2} ${ucdPackagingScript} --buztool ${BuzTool} --workDir ${logDir} --component ${UcdComp} --versionName ${UcdVers}"
 
     # external repository file
     if [ ! -z "${ExtRepoProp}" ]; then


### PR DESCRIPTION
The two templates `packageBuildOutputs.sh` and `ucdPackaging.sh` previously have resolved the dbb runtime via the PATH environment variable.

The build wrapper script leveraged the `DBB_HOME` environment variable.

The below updates aim for consistency and align with the DBB environment variables.