### PR TITLE
Common Backend Scripts - Add debug flag to Basic Pipeline workflow for main branch

### DIFF
--- a/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
+++ b/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
@@ -130,10 +130,8 @@ computeBuildConfiguration() {
                 HLQ="${HLQ}.${mainBranchSegmentTrimmed:0:8}.REL"
             else
                 HLQ="${HLQ}.${mainBranchSegmentTrimmed:0:8}.BLD"
-                if [ -z "${Type}" ]; then
-                    # appending the --debug flag to compile with TEST options
-                    Type="${Type} --debug"
-                fi
+                # appending the --debug flag to compile with TEST options
+                Type="${Type} --debug"
             fi
 
             ;;


### PR DESCRIPTION
This is implementing defect #217 

The common backend scripts missed to add the debug `--debug` flag for the basic build pipeline for the main branch.

While the `--debug` is a mandatory field for this workflow, it is sufficient to just remove the condition and append the debug options. 