### PR TITLE
AzureDevOps Pipeline to reference variable for verbose logging

### DIFF
--- a/Templates/AzureDevOpsPipeline/azure-pipelines.yml
+++ b/Templates/AzureDevOpsPipeline/azure-pipelines.yml
@@ -142,7 +142,7 @@ stages:
             inputs:
               sshEndpoint: $(zosSSHConnection)
               runOptions: "commands"
-              commands: ". ./.profile && dbbBuild.sh -w $(uniqueWorkspaceId) -a $(application) -b $(branch) -p $(pipelineType) $(verbose)"
+              commands: ". ./.profile && dbbBuild.sh -w $(uniqueWorkspaceId) -a $(application) -b $(branch) -p $(pipelineType) ${{variables.verbose}}"
               readyTimeout: "20000"
             displayName: "Build application"
       - job: PublishBuildLogs


### PR DESCRIPTION
This is addressing an issue introduced with #216 . 216 has missed to reference the verbose flag as a variable.