### PR TITLE
Update computation of release and release candidate tags for release branches

### DIFF
--- a/Templates/AzureDevOpsPipeline/templates/tagging/createReleaseCandidate.yml
+++ b/Templates/AzureDevOpsPipeline/templates/tagging/createReleaseCandidate.yml
@@ -55,7 +55,7 @@ steps:
               baselineRef=$(cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" ' { print $2 }')
               ;;
             "release")
-              baselineRef=$(cat "${baselineReferenceFile}" | grep "^${secondBranchSegment}" | awk -F "=" ' { print $2 }')
+              baselineRef=$(cat "${baselineReferenceFile}" | grep "^release/${secondBranchSegment}" | awk -F "=" ' { print $2 }')
               ;;
           esac
 
@@ -99,7 +99,7 @@ steps:
             export newVersionTag=$(echo "${newVersionTag}_rc00" | tr -d \")
           else
             # bump up release candidate number
-            export newVersionTag=$(echo $releaseCandidate | sed 's/^["refs\/tags\/rel-]*//g' | awk -F "rc" '{print "rel-"$1"rc"(-f2 $2+1)}' | tr -d \")
+            export newVersionTag=$(echo $releaseCandidate | sed 's/^["refs\/tags\/rel-]*//g' | awk -F "rc" '{a=++$2; printf("rel-"$1"rc%02d\n",a)}' | tr -d \")
           fi
 
         fi

--- a/Templates/AzureDevOpsPipeline/templates/tagging/createReleaseCandidate.yml
+++ b/Templates/AzureDevOpsPipeline/templates/tagging/createReleaseCandidate.yml
@@ -52,10 +52,10 @@ steps:
 
           case $mainBranchSegment in
             "main")
-              baselineRef=$(cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" ' { print $2 }')
+              baselineRef=$(cat "${baselineReferenceFile}" | grep -m 1 "^${mainBranchSegment}" | awk -F "=" ' { print $2 }')
               ;;
             "release")
-              baselineRef=$(cat "${baselineReferenceFile}" | grep "^release/${secondBranchSegment}" | awk -F "=" ' { print $2 }')
+              baselineRef=$(cat "${baselineReferenceFile}" | grep -m 1 "^release/${secondBranchSegment}" | awk -F "=" ' { print $2 }')
               ;;
           esac
 

--- a/Templates/GitlabCIPipeline/.gitlab-ci.yml
+++ b/Templates/GitlabCIPipeline/.gitlab-ci.yml
@@ -204,7 +204,7 @@ Clone:
                     export baselineRef=`cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
                 "release")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
             esac
 
@@ -238,7 +238,7 @@ Clone:
                 echo [INFO] Updated release candidate tag: ${newVersionTag}
             else
             # bump up release candidate number
-                export newVersionTag=`echo ${releaseCandidate} | sed 's/^["refs\/tags\/rel-]*//g' | awk -F "rc" '{print "rel-"$1"rc"(-f2 $2+1)}' | tr -d \"`
+                export newVersionTag=`echo ${releaseCandidate} | sed 's/^["refs\/tags\/rel-]*//g' | awk -F "rc" '{a=++$2; printf("rel-"$1"rc%02d\n",a)}' | tr -d \"`
                 echo [INFO] Updated release candidate tag: ${newVersionTag}
             fi
 
@@ -617,7 +617,7 @@ Create production version:
                     export baselineRef=`cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
                 "release")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
             esac
 

--- a/Templates/GitlabCIPipeline/.gitlab-ci.yml
+++ b/Templates/GitlabCIPipeline/.gitlab-ci.yml
@@ -201,10 +201,10 @@ Clone:
             # Find base line version of the current branch from the baseLineReferenceFile
             case ${mainBranchSegment} in
                 "main")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
                 "release")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
             esac
 
@@ -614,10 +614,10 @@ Create production version:
             # Find base line version of the current branch from the baseLineReferenceFile
             case ${mainBranchSegment} in
                 "main")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
                 "release")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
             esac
 


### PR DESCRIPTION
This is implementing 
* correct computation of the baseline tag for computing the next release.
* and fixes the computation of release candidate numbers as reported in #230 