### PR TITLE
Implement option to set HTTP Client Protocol version for ArtifactRepositoryHelpers

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -578,7 +578,7 @@ def parseInput(String[] cliArgs){
 	cli.ad(longOpt:'artifactRepositoryDirectory', args:1, argName:'repoDirectory', 'Directory path in the repository to store the build . (Optional)')
 	cli.aU(longOpt:'artifactRepositoryUser', args:1, argName:'user', 'User to connect to the Artifact repository server. (Optional)')
 	cli.aP(longOpt:'artifactRepositoryPassword', args:1, argName:'password', 'Password to connect to the Artifact repository server. (Optional)')
-	cli.ah(longOpt:'artifactRepositoryHttpClientProtocolVersion', args:1, argName: httpClientProtocolVersion, 'HttpClient.Version setting to override the HTTP protocol version. (Optional)')
+	cli.ah(longOpt:'artifactRepositoryHttpClientProtocolVersion', args:1, argName: 'httpClientProtocolVersion', 'HttpClient.Version setting to override the HTTP protocol version. (Optional)')
 	cli.aprop(longOpt:'artifactRepositoryPropertyFile', args:1, argName:'propertyFile', 'Path of a property file containing application specific artifact repository details. (Optional) ** (Deprecated)')
 
 	// Tracing

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -475,6 +475,7 @@ if (buildOutputsMap.size() == 0) {
 		def apiKey = props.'artifactRepository.user'
 		def user = props.'artifactRepository.user'
 		def password = props.'artifactRepository.password'
+		def httpClientVersion = props.'artifactRepository.httpClientVersion'
 		def repo = props.get('artifactRepository.repo') as String
 
 		//Call the artifactRepositoryHelpers to publish the tar file
@@ -483,7 +484,7 @@ if (buildOutputsMap.size() == 0) {
 		GroovyObject artifactRepositoryHelpers = (GroovyObject) artifactRepositoryHelpersClass.newInstance()
 
 		println ("** Uploading package to Artifact Repository $url...")
-		artifactRepositoryHelpers.upload(url, tarFile as String, user, password, props.verbose.toBoolean() )
+		artifactRepositoryHelpers.upload(url, tarFile as String, user, password, props.verbose.toBoolean(), httpClientVersion)
 	}
 
 	if (props.error) {
@@ -577,6 +578,7 @@ def parseInput(String[] cliArgs){
 	cli.ad(longOpt:'artifactRepositoryDirectory', args:1, argName:'repoDirectory', 'Directory path in the repository to store the build . (Optional)')
 	cli.aU(longOpt:'artifactRepositoryUser', args:1, argName:'user', 'User to connect to the Artifact repository server. (Optional)')
 	cli.aP(longOpt:'artifactRepositoryPassword', args:1, argName:'password', 'Password to connect to the Artifact repository server. (Optional)')
+	cli.ah(longOpt:'artifactRepositoryHttpClientProtocolVersion', args:1, argName: httpClientProtocolVersion, 'HttpClient.Version setting to override the HTTP protocol version. (Optional)')
 	cli.aprop(longOpt:'artifactRepositoryPropertyFile', args:1, argName:'propertyFile', 'Path of a property file containing application specific artifact repository details. (Optional) ** (Deprecated)')
 
 	// Tracing
@@ -652,6 +654,7 @@ def parseInput(String[] cliArgs){
 	if (opts.au) props.'artifactRepository.url' = opts.au
 	if (opts.ar) props.'artifactRepository.repo' = opts.ar
 	if (opts.ad) props.'artifactRepository.directory' = opts.ad
+	if (opts.ah) props.'artifactRepository.httpClientVersion' = opts.ah
 
 	//add any build reports from the file first, then add any from a CLI after.
 	//if no file or CLI, go to default build report

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -434,6 +434,7 @@ Parameter | Description
 `artifactRepository.directory` | Artifact repository directory to distinguish between prelimiary versions and release candidates, e.q. rel-1.0.0
 `artifactRepository.user` | User name
 `artifactRepository.password` | Password, Personal Access Token
+`artifactRepository.httpClientVersion` | HttpClient.Version setting to override the HTTP protocol version (Optional)
 
 
 ## Command Line Options Summary - PackageBuildOutputs
@@ -508,7 +509,9 @@ Parameter | Description
   
   -aP,--artifactRepositoryPassword <password>
                      Password to connect to the Artifact repository server. (Optional)
-
+  
+  -ah,--artifactRepositoryHttpClientProtocolVersion <protocolVersion>
+                     HttpClient.Version setting to override the HTTP protocol version. (Optional)
 ```
 
 ## Command Line Options Summary - ArtifactRepositoryHelpers
@@ -523,6 +526,7 @@ usage: ArtifactRepositoryHelpers.groovy [options]
  -u,--url <arg>               Artifactory file uri location
  -U,--user <arg>              Artifactory user id
  -v,--verbose                 Flag to turn on script trace
+ -ht,--httpClientVersion      Http Client Protocol Version (Optional)
 ```
 
 

--- a/Pipeline/PackageBuildOutputs/appArtifactRepository.properties
+++ b/Pipeline/PackageBuildOutputs/appArtifactRepository.properties
@@ -21,3 +21,9 @@ artifactRepository.directory=
 # Artifact repository credentials
 artifactRepository.user=
 artifactRepository.password=
+
+# (Optional) HttpClient.Version setting to override the HTTP protocol version
+# see https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.Version.html
+# HTTP_1_1 - HTTP version 1.1
+# HTTP_2 - HTTP version 2
+artifactRepository.httpClientVersion=HTTP_1_1

--- a/Pipeline/PackageBuildOutputs/appArtifactRepository.properties
+++ b/Pipeline/PackageBuildOutputs/appArtifactRepository.properties
@@ -26,4 +26,4 @@ artifactRepository.password=
 # see https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.Version.html
 # HTTP_1_1 - HTTP version 1.1
 # HTTP_2 - HTTP version 2
-artifactRepository.httpClientVersion=HTTP_1_1
+artifactRepository.httpClientVersion=


### PR DESCRIPTION
This is implementing the enhancement to allow the user to define the HTTP Client protocol version for the HTTP Request. 

See enhancement request #237 .

The issue was observed implementing a pipeline with the Nexus in the OSS version.

The user can set the httpClient protocol version via:
* CLI parm for PackageBuildOutputs
* Property Setting for application specific artefact repository settings
* CLI for ArtifactRepositoryHelpers.groovy