### PR TITLE
Exit with non-zero return code when BuildReport does not contain outputs

### DIFF
--- a/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
+++ b/Pipeline/CreateUCDComponentVersion/dbb-ucd-packaging.groovy
@@ -243,7 +243,7 @@ tempBuildOutputsMap.each { deployableArtifact, info ->
 
 if (buildOutputsMap.size() == 0) {
     println("** No items to package in the provided build reports. Exiting.")
-    System.exit(0)
+    System.exit(4)
 }
 
 // generate ship list file. specification of UCD ship list can be found at


### PR DESCRIPTION
This is implementing issue #222 to return with a non-zero return code when there were not items found that need to be packaged.

Any subsequent scripts can assess the return code instead of having to parse the log output.