### PR TITLE
Uplift GitLab template and persist WD evidences

### DIFF
--- a/Templates/GitlabCIPipeline/.gitlab-ci.yml
+++ b/Templates/GitlabCIPipeline/.gitlab-ci.yml
@@ -7,6 +7,9 @@ variables:
     wdEnvironmentFileAcceptance: ${WAZI_DEPLOY_CONFIGDIR}/plum-samples/external-repos/environment-conf/python/Acceptance.yml
     wdEnvironmentFileProduction: ${WAZI_DEPLOY_CONFIGDIR}/plum-samples/external-repos/environment-conf/python/Production.yml
     packageName: ${application}.build-${CI_PIPELINE_ID}
+    # Directories on the GitLab runner environment to persist Wazi Deploy Evidence files and to create an Wazi Deploy Index
+    wdEvidencesRoot: /var/work/wazi_deploy_evidences_gitlab/
+    wdEvidencesIndex: /var/work/wazi_deploy_evidences_gitlab_index/
 
  # Working directory on USS 
     uniqueWorkspaceId: $PIPELINE_WORKSPACE/$CI_PROJECT_NAME/build-${CI_PIPELINE_ID}
@@ -28,8 +31,16 @@ variables:
         - "major"
         - "minor"
         - "patch"
-        description: "The release type to idicate the scope of the release: a major, minor or patch (bug fixes) release"
-            
+        description: "The release type to indicate the scope of the release: a major, minor or patch (bug fixes) release"
+
+# Only run pipeline on push and manual request, not on tags
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "web"
+
 stages:
     - Setup
     - Build
@@ -54,8 +65,9 @@ Clone:
       # Clone and checkout git repo to get latest update.
       GIT_STRATEGY: clone
       GIT_CHECKOUT: "true"
-      # To set the clone depth to 0, uncomment the following line
-      # GIT_DEPTH: 0
+      # To set the clone depth to 0
+      # This is necessary to calculate the next release tag, which implementation lists the existing tags
+      GIT_DEPTH: 0
     script: |
         # Environment parameters
         echo Environment parameters
@@ -70,7 +82,7 @@ Clone:
         echo [INFO] Release Type = ${releaseType}
         echo [INFO] Verbose = ${verbose}
         # Git clone
-        zowe rse issue unix ". ~/.bash_profile && gitClone.sh -w ${uniqueWorkspaceId} -r ${CI_REPOSITORY_URL} -b ${CI_COMMIT_REF_NAME} -a ${application}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && gitClone.sh -w ${uniqueWorkspaceId} -r ${CI_REPOSITORY_URL} -b ${CI_COMMIT_REF_NAME} -a ${application}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Clone job passed.
@@ -83,10 +95,6 @@ Clone:
     needs: ["Clone"]
     stage: Build
     tags: [shell]
-    rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - when: on_success
     dependencies: []
     artifacts:
         name: "report-${CI_PIPELINE_ID}"
@@ -96,12 +104,12 @@ Clone:
         reports:
             junit: "$CI_PROJECT_DIR/BUILD-OUTPUT/*.xml"
     script: |
-        zowe rse issue unix ". ~/.bash_profile && env|sort && dbbBuild.sh -w ${uniqueWorkspaceId} -a ${application} -b ${CI_COMMIT_REF_NAME} -p ${pipelineType} ${verbose}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && dbbBuild.sh -w ${uniqueWorkspaceId} -a ${application} -b ${CI_COMMIT_REF_NAME} -p ${pipelineType} -t '--fullBuild' ${verbose}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Build job passed.
         else
-             if [ ${RC} -eq 0 ]; then
+             if [ ${RC} -eq 4 ]; then
                 echo [WARNING] Build job failed due to no source code changes. Exit code: ${RC}.
             else
                 echo [ERROR] Build job failed. Exit code: ${RC}.
@@ -114,9 +122,7 @@ Clone:
     stage: Build
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never 
-        - when: on_success
+        - when: always
     dependencies: []
     variables:
         sourceLogsFile: ${uniqueWorkspaceId}/logs.tar
@@ -125,7 +131,7 @@ Clone:
         name: "buildReport-${CI_PIPELINE_ID}"
         when: always
         paths:
-            # Uncomment or comment the type of file that o not want to publish to Gitlab artifacts
+            # Uncomment or comment the type of file to (or not) publish to Gitlab artifacts
             - "${buildOutputDirectory}/*.log"
             - "${buildOutputDirectory}/*.html"
             - "${buildOutputDirectory}/*.json"
@@ -133,8 +139,10 @@ Clone:
             #- "${buildOutputDirectory}/*.pdf"
             #- "${buildOutputDirectory}/*.cczip"
             - "${buildOutputDirectory}/*.txt"
+            #- "${buildOutputDirectory}/*SONARQUBE/*.*"
+            # "${buildOutputDirectory}/logs.tar"
     script: |
-        zowe rse issue unix ". ~/.bash_profile && prepareLogs.sh -w ${uniqueWorkspaceId}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && prepareLogs.sh -w ${uniqueWorkspaceId}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Prepared build log files.
@@ -166,16 +174,12 @@ Clone:
         fi
 
 3-Create release candidate tag:
-    needs: ["2-Prepare and publish build logs"]
+    needs: ["1-Build application", "2-Prepare and publish build logs"]
     stage: Build
     tags: [shell]
     rules:
         # The job only run if the pipelineType is "release".
-        - if: $CI_COMMIT_TAG
-          when: never
-        - if: $pipelineType != "release"
-          when: never
-        - when: on_success
+        - if: $pipelineType == "release"
     variables:
       # Clone and checkout git repo to get latest baselineReference config file.
       GIT_STRATEGY: clone
@@ -196,15 +200,17 @@ Clone:
             export thirdBranchSegment=`echo ${CI_COMMIT_BRANCH} | awk -F "/" '{ print $3 }'`
 
             echo [INFO] Branch: ${CI_COMMIT_BRANCH}
-            echo [INFO] Branch segment: ${mainBranchSegment}, ${secondBranchSegment}, ${thirdBranchSegment}
+            # echo [INFO] Branch segments: ${mainBranchSegment}, ${secondBranchSegment}, ${thirdBranchSegment}
 
             # Find base line version of the current branch from the baseLineReferenceFile
             case ${mainBranchSegment} in
                 "main")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
                 "release")
+                    # echo [INFO] Extract baseline for release branch
                     export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^release/${secondBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    #echo [INFO] Baselinereference = ${baselineRef}
               ;;
             esac
 
@@ -254,13 +260,14 @@ Clone:
         fi
 
 Packaging:
-    needs: ["2-Prepare and publish build logs"]
+    needs: ["1-Build application", "2-Prepare and publish build logs"]
     stage: Packaging
     tags: [shell]
+    # Run packaging only on integration branches
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - when: on_success
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /release\/.*/  && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /epic\/.*/  && $pipelineType != "preview"
     dependencies: []
     script: |
 
@@ -278,11 +285,9 @@ Packaging:
     stage: Deploy Integration
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never 
-        - if: $pipelineType == "preview"
-          when: never
-        - when: on_success
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /release\/.*/  && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /epic\/.*/  && $pipelineType != "preview"
     script: |
 
         zowe rse issue unix ". ~/.bash_profile && wazideploy-generate.sh -w ${uniqueWorkspaceId} -i ${application}.tar" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
@@ -299,11 +304,9 @@ Packaging:
     stage: Deploy Integration
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never 
-        - if: $pipelineType == "preview"
-          when: never
-        - when: on_success 
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /release\/.*/  && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /epic\/.*/  && $pipelineType != "preview"    
     dependencies: []
     script: |
         
@@ -321,16 +324,16 @@ Packaging:
     stage: Deploy Integration
     tags: [shell]    
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never 
-        - if: $pipelineType == "preview"
-          when: never
-        - when: on_success
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /release\/.*/  && $pipelineType != "preview"
+        - if: $CI_COMMIT_BRANCH =~ /epic\/.*/  && $pipelineType != "preview" 
     dependencies: []
     variables:
         sourceOutputFile: ${uniqueWorkspaceId}/deployPkgDir/deploy/deployment-report.html
         sourceEvidenceFile: ${uniqueWorkspaceId}/deployPkgDir/deploy/evidences/evidence.yaml
         integrationReportDir: ${deployOutputDirectory}/deploy-integration
+        # directory to persist the evidence files
+        wdEvidencesDir: ${wdEvidencesRoot}/${application}/integration
     
     artifacts:
         name: "integrationDeploymentReport-${CI_PIPELINE_ID}"
@@ -377,30 +380,40 @@ Packaging:
                 exit ${RC}
             fi
             echo [INFO] Published Deployment report.
+
+            # Persist the evidence file for Wazi Deploy evidence indexing
+            
+            # create evidence dir
+            if [ ${RC} -eq 0 ]; then
+                CMD="mkdir -p $wdEvidencesDir && mkdir -p $wdEvidencesIndex"
+                ${CMD}
+                RC=$?
+            fi
+
+            # Copy evidence File
+            if [ ${RC} -eq 0 ]; then
+                CMD="cp ${integrationReportDir}/evidence.yaml $wdEvidencesDir/evidence-${CI_PIPELINE_ID}.yaml"
+                ${CMD}
+                RC=$?
+                echo [INFO] Persisted deployment evidence file at $wdEvidencesDir.
+            fi
+
+            # Refresh index of all applications
+            if [ ${RC} -eq 0 ]; then
+                wazideploy-evidence --index $wdEvidencesIndex --dataFolder $wdEvidencesRoot i
+                RC=$?
+            fi
+            # Error Handling
+            if [ ${RC} -eq 0 ]; then
+                echo "[INFO] - Update Wazi Deploy index completed."
+            else
+                echo "[WARNING] - Update Wazi Deploy index failed."
+                exit ${RC}
+            fi
+
         else
             echo [ERROR] Failed to generate deployment evidence file. Exit code: ${RC}.
             exit ${RC}
-        fi
-
-4-Cleanup Development:
-    stage: Deploy Integration
-    tags: [shell]    
-    variables:
-      FF_ENABLE_JOB_CLEANUP: 1
-    rules:
-        - if: $CI_COMMIT_TAG
-          when: never 
-        - if: $pipelineType == "preview"
-          when: never
-        - when: manual
-    script: |
-        zowe rse issue unix ". ~/.bash_profile && deleteWorkspace.sh -w ${uniqueWorkspaceId}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
-        RC=$?
-        if [ ${RC} -eq 0 ]; then
-            echo [INFO] Clean up development job passed.
-        else
-             echo [ERROR] Clean up development job failed. Exit code: ${RC}.
-             exit ${RC}
         fi
 
 1-Deploy to Acceptance:
@@ -408,11 +421,12 @@ Packaging:
     stage: Deploy Acceptance
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - if: $pipelineType == "preview" || $pipelineType == "build"
-          when: never
-        - when: manual 
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType == "release"
+          when: manual
+        - if: $CI_COMMIT_BRANCH =~ /release\/.*/ && $pipelineType == "release"
+          when: manual
+        - if: $CI_COMMIT_BRANCH =~ /epic\/.*/ && $pipelineType == "release"
+          when: manual          
     dependencies: []
     script: |
         zowe rse issue unix ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileAcceptance} -i ${application}.tar -l deploy-acceptance/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
@@ -429,16 +443,15 @@ Packaging:
     stage: Deploy Acceptance
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - if: $pipelineType == "preview" || $pipelineType == "build"
-          when: never
-        - when: on_success
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType == "release"
+        - if: $CI_COMMIT_BRANCH =~ /release\/.*/ && $pipelineType == "release"
+        - if: $CI_COMMIT_BRANCH =~ /epic\/.*/ && $pipelineType == "release"
     dependencies: []
     variables:
         sourceOutputFile: ${uniqueWorkspaceId}/deployPkgDir/deploy-acceptance/deployment-report.html
         sourceEvidenceFile: ${uniqueWorkspaceId}/deployPkgDir/deploy-acceptance/evidences/evidence.yaml
         acceptanceReportDir: ${deployOutputDirectory}/deploy-acceptance
+        wdEvidencesDir: ${wdEvidencesRoot}/${application}/acceptance
     artifacts:
         name: "acceptanceDeploymentReport-${CI_PIPELINE_ID}"
         when: always
@@ -446,7 +459,7 @@ Packaging:
             - "${acceptanceReportDir}/deployment-report.html"
             - "${acceptanceReportDir}/evidence.yaml"
     script: |
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-evidence.sh -w ${uniqueWorkspaceId} -l deploy-acceptance/evidences/evidence.yaml -o deploy-acceptance/deployment-report.html" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-evidence.sh -w ${uniqueWorkspaceId} -l deploy-acceptance/evidences/evidence.yaml -o deploy-acceptance/deployment-report.html" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Generated deployment evidence.
@@ -463,7 +476,8 @@ Packaging:
             # Create acceptance report directory
             mkdir ${acceptanceReportDir}
             echo [INFO] Created acceptance report directory: ${acceptanceReportDir}
-            # Transfer acceptnace deployment report and evidence report
+            
+            # Transfer acceptance deployment report and evidence report
             echo [INFO] Start loading deployment reports from ${sourceOutputFile} to ${acceptanceReportDir}/deployment-report.html
             zowe rse dl uf "${sourceOutputFile}" -f "${acceptanceReportDir}/deployment-report.html" -b --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD}
             RC=$?
@@ -483,6 +497,37 @@ Packaging:
                 exit ${RC}
             fi
             echo [INFO] Published Deployment report.
+
+            # Persist the evidence file for Wazi Deploy evidence indexing
+            
+            # create evidence dir
+            if [ ${RC} -eq 0 ]; then
+                CMD="mkdir -p $wdEvidencesDir && mkdir -p $wdEvidencesIndex"
+                ${CMD}
+                RC=$?
+            fi
+
+            # Copy evidence File
+            if [ ${RC} -eq 0 ]; then
+                CMD="cp ${acceptanceReportDir}/evidence.yaml $wdEvidencesDir/evidence-${CI_PIPELINE_ID}.yaml"
+                ${CMD}
+                RC=$?
+                echo [INFO] Persisted deployment evidence file at $wdEvidencesDir.
+            fi
+
+            # Refresh index of all applications
+            if [ ${RC} -eq 0 ]; then
+                wazideploy-evidence --index $wdEvidencesIndex --dataFolder $wdEvidencesRoot i
+                RC=$?
+            fi
+            # Error Handling
+            if [ ${RC} -eq 0 ]; then
+                echo "[INFO] - Update Wazi Deploy index completed."
+            else
+                echo "[WARNING] - Update Wazi Deploy index failed."
+                exit ${RC}
+            fi
+
         else
             echo [ERROR] Failed to generate deployment evidence file. Exit code: ${RC}.
             exit ${RC}
@@ -494,14 +539,13 @@ Packaging:
     stage: Deploy Production
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - if: $pipelineType == "preview" || $pipelineType == "build"
-          when: never
-        - when: manual
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType == "release"
+          when: manual
+        - if: $CI_COMMIT_BRANCH =~ /release.*/ && $pipelineType == "release"
+          when: manual
     dependencies: []
     script: |
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileProduction} -i ${application}.tar -l deploy-production/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileProduction} -i ${application}.tar -l deploy-production/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Deploy to production job passed.
@@ -515,16 +559,15 @@ Packaging:
     stage: Deploy Production
     tags: [shell]
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - if: $pipelineType == "preview" || $pipelineType == "build"
-          when: never
-        - when: on_success
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType == "release"
+        - if: $CI_COMMIT_BRANCH =~ /release.*/ && $pipelineType == "release"
     dependencies: []
     variables:
         sourceOutputFile: ${uniqueWorkspaceId}/deployPkgDir/deploy-production/deployment-report.html
         sourceEvidenceFile: ${uniqueWorkspaceId}/deployPkgDir/deploy-production/evidences/evidence.yaml
         productionReportDir: ${deployOutputDirectory}/deploy-production
+        wdEvidencesDir: ${wdEvidencesRoot}/${application}/production
+
     artifacts:
         name: “productionDeploymentReport-${CI_PIPELINE_ID}"
         when: always
@@ -532,7 +575,7 @@ Packaging:
             - "${productionReportDir}/deployment-report.html"
             - "${productionReportDir}/evidence.yaml"
     script: |
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-evidence.sh -w ${uniqueWorkspaceId} -l deploy-production/evidences/evidence.yaml -o deploy-production/deployment-report.html" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-evidence.sh -w ${uniqueWorkspaceId} -l deploy-production/evidences/evidence.yaml -o deploy-production/deployment-report.html" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Generated deployment evidence.
@@ -570,6 +613,35 @@ Packaging:
                 exit ${RC}
             fi
             echo [INFO] Published Deployment report.
+
+            # Persist the evidence file for Wazi Deploy evidence indexing
+            # create evidence dir
+            if [ ${RC} -eq 0 ]; then
+                CMD="mkdir -p $wdEvidencesDir && mkdir -p $wdEvidencesIndex"
+                ${CMD}
+                RC=$?
+            fi
+
+            # Copy evidence File
+            if [ ${RC} -eq 0 ]; then
+                CMD="cp ${productionReportDir}/evidence.yaml $wdEvidencesDir/evidence-${CI_PIPELINE_ID}.yaml"
+                ${CMD}
+                RC=$?
+                echo [INFO] Persisted deployment evidence file at $wdEvidencesDir.
+            fi
+
+            # Refresh index of all applications
+            if [ ${RC} -eq 0 ]; then
+                wazideploy-evidence --index $wdEvidencesIndex --dataFolder $wdEvidencesRoot i
+                RC=$?
+            fi
+            # Error Handling
+            if [ ${RC} -eq 0 ]; then
+                echo "[INFO] - Update Wazi Deploy index completed."
+            else
+                echo "[WARNING] - Update Wazi Deploy index failed."
+                exit ${RC}
+            fi
         else
             echo [ERROR] Failed to generate deployment evidence file. Exit code: ${RC}.
             exit ${RC}
@@ -583,11 +655,8 @@ Create production version:
         GIT_STRATEGY: clone
         GIT_CHECKOUT: "true"
     rules:
-        - if: $CI_COMMIT_TAG
-          when: never
-        - if: $pipelineType == "preview" || $pipelineType == "build"
-          when: never
-        - when: manual
+        - if: $CI_COMMIT_BRANCH == "main" && $pipelineType == "release"
+        - if: $CI_COMMIT_BRANCH =~ /release.*/ && $pipelineType == "release"
 
     script: |    
 
@@ -673,19 +742,12 @@ Create production version:
         fi
 
 Cleanup:
-    needs: ["Create production version"]
     stage: Cleanup
     tags: [shell]
     variables:
       FF_ENABLE_JOB_CLEANUP: 1
-    rules:
-        - if: $CI_COMMIT_TAG
-          when: never 
-        - if: $pipelineType == "preview" || $pipelineType == "build"
-          when: never
-        - when: manual
     script: |
-        zowe rse issue unix ". ~/.bash_profile && deleteWorkspace.sh -w ${uniqueWorkspaceId}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && deleteWorkspace.sh -w ${uniqueWorkspaceId}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Cleanup job passed.

--- a/Templates/GitlabCIPipeline/.gitlab-ci.yml
+++ b/Templates/GitlabCIPipeline/.gitlab-ci.yml
@@ -104,7 +104,7 @@ Clone:
         reports:
             junit: "$CI_PROJECT_DIR/BUILD-OUTPUT/*.xml"
     script: |
-        zowe rse issue unix-shell ". ~/.bash_profile && dbbBuild.sh -w ${uniqueWorkspaceId} -a ${application} -b ${CI_COMMIT_REF_NAME} -p ${pipelineType} -t '--fullBuild' ${verbose}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && dbbBuild.sh -w ${uniqueWorkspaceId} -a ${application} -b ${CI_COMMIT_REF_NAME} -p ${pipelineType} ${verbose}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Build job passed.
@@ -205,7 +205,7 @@ Clone:
             # Find base line version of the current branch from the baseLineReferenceFile
             case ${mainBranchSegment} in
                 "main")
-                    export baselineRef=`cat "${baselineReferenceFile}" | grep "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
+                    export baselineRef=`cat "${baselineReferenceFile}" | grep -m 1 "^${mainBranchSegment}" | awk -F "=" '{ print $2 }'`
               ;;
                 "release")
                     # echo [INFO] Extract baseline for release branch
@@ -235,7 +235,7 @@ Clone:
             echo [INFO] Computed tag for the next release: ${newVersionTag}
 
             # Compute the name of the next release candidate 
-            export releaseCandidate=$(git tag --list "${newVersionTag}_*rc*" --sort=-committerdate | head -n 1)
+            export releaseCandidate=$(git tag --list "${newVersionTag}_*rc*" --sort=version:refname | tail -n 1)
             echo [INFO] Current release candidate tag: ${releaseCandidate}
 
             if [ -z "${releaseCandidate}" ]; then
@@ -271,7 +271,7 @@ Packaging:
     dependencies: []
     script: |
 
-        zowe rse issue unix ". ~/.bash_profile && packageBuildOutputs.sh -w ${uniqueWorkspaceId} -t ${application}.tar -a ${application} -b ${CI_COMMIT_REF_NAME} -p ${pipelineType} -v ${packageName}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && packageBuildOutputs.sh -w ${uniqueWorkspaceId} -t ${application}.tar -a ${application} -b ${CI_COMMIT_REF_NAME} -p ${pipelineType} -v ${packageName}" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Packaging job passed.
@@ -290,7 +290,7 @@ Packaging:
         - if: $CI_COMMIT_BRANCH =~ /epic\/.*/  && $pipelineType != "preview"
     script: |
 
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-generate.sh -w ${uniqueWorkspaceId} -i ${application}.tar" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-generate.sh -w ${uniqueWorkspaceId} -i ${application}.tar" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Generate deployment plan job passed.
@@ -310,7 +310,7 @@ Packaging:
     dependencies: []
     script: |
         
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileIntegration} -i ${application}.tar -l deploy/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileIntegration} -i ${application}.tar -l deploy/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Deploy to integration job passed.
@@ -322,7 +322,7 @@ Packaging:
 3-Generate and publish deployment report for Integration:
     needs: ["2-Deploy to Integration"]
     stage: Deploy Integration
-    tags: [shell]    
+    tags: [shell]
     rules:
         - if: $CI_COMMIT_BRANCH == "main" && $pipelineType != "preview"
         - if: $CI_COMMIT_BRANCH =~ /release\/.*/  && $pipelineType != "preview"
@@ -343,7 +343,7 @@ Packaging:
             - "${integrationReportDir}/evidence.yaml"
     script: |
         type zowe
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-evidence.sh -w ${uniqueWorkspaceId} -l deploy/evidences/evidence.yaml -o deploy/deployment-report.html" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-evidence.sh -w ${uniqueWorkspaceId} -l deploy/evidences/evidence.yaml -o deploy/deployment-report.html" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Generated deployment evidence.
@@ -429,7 +429,7 @@ Packaging:
           when: manual          
     dependencies: []
     script: |
-        zowe rse issue unix ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileAcceptance} -i ${application}.tar -l deploy-acceptance/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
+        zowe rse issue unix-shell ". ~/.bash_profile && wazideploy-deploy.sh -w ${uniqueWorkspaceId} -e ${wdEnvironmentFileAcceptance} -i ${application}.tar -l deploy-acceptance/evidences/evidence.yaml < /dev/null" --user ${RSEAPI_USER} --password ${RSEAPI_PASSWORD} --cwd ${RSEAPI_WORKING_DIRECTORY}
         RC=$?
         if [ ${RC} -eq 0 ]; then
             echo [INFO] Deploy to acceptance job passed.

--- a/Templates/GitlabCIPipeline/README.md
+++ b/Templates/GitlabCIPipeline/README.md
@@ -39,7 +39,7 @@ The pipeline uses the Gitlab concepts: `Stage`and `Jobs`.
 
 To leverages this template, access to a Gitlab CI/CD environment is required, and an Gitlab runner must be configured to connect to your mainframe environment. Please review the setup instructions of this [document](https://www.ibm.com/support/pages/system/files/inline-files/Integrating%20IBM%20zOS%20platform%20in%20CICD%20pipelines%20with%20GitLab%20-%20v1.7_1.pdf).
 
-The template leverages [Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli/) to issue command invoking the [Common Backend scripts](../Common-Backend-Scripts/) on USS. It specifically uses the `issue unix-shell` command which allows streaming of the console outputs back the Zowe CLI task.
+The template leverages [Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli/) to issue command invoking the [Common Backend scripts](../Common-Backend-Scripts/) on USS. It specifically uses the `issue unix-shell` command which allows streaming of the console outputs back to the Zowe Command-Line Interface, that was introduced in IBM RSE API Plug-in for Zowe CLI version 4.0.0 (see [Changelog](https://marketplace.visualstudio.com/items/IBM.zopeneditor/changelog))
 
 * Zowe `base` and `rse` profiles needs to be configured in the `zowe.config.json` file under `.zowe` directory
 

--- a/Templates/GitlabCIPipeline/README.md
+++ b/Templates/GitlabCIPipeline/README.md
@@ -18,14 +18,15 @@ The pipeline implements the following stages
   * to deploy the package with the Wazi Deploy [deploy command](../Common-Backend-Scripts/README.md#48---wazideploy-deploysh) (Python-based)
   * to run the Wazi Deploy [evidence command](../Common-Backend-Scripts/README.md#49---wazideploy-evidencesh) to generate deployment report and updating the evidence.
   * to publish deployment log files to the Gitlab Artifacts.
-  * (Optional) to cleanup the working directory on Gitlab and the build workpsace on  z/OS Unix System Services. This job can be trigger manually when you donnot need to deploy to higher test environment.
+  * to store the Wazi Deploy evidence files at a shared location to support later reporting scenarios.
 * `Deploy Acceptance` and `Deploy Production` stages to deploy to controlled test environments via the [release pipeline](https://ibm.github.io/z-devops-acceleration-program/docs/branching-model-supporting-pipeline#the-release-pipeline-with-build-packaging-and-deploy-stages) that includes:
   * to deploy the package with the Wazi Deploy to targeted environment [deploy command](../Common-Backend-Scripts/README.md#48---wazideploy-deploysh) (Python-based)
   * to run the Wazi Deploy [evidence command](../Common-Backend-Scripts/README.md#49---wazideploy-evidencesh) to generate deployment report and updating the evidence.
   * to publish deployment log files to the Gitlab Artifacts.
+  * to store the Wazi Deploy evidence files at a shared location to support later reporting scenarios.
 * `Finalize` stage to create a release tag from [baseline reference file](../Common-Backend-Scripts/samples/baselineReference.config) and create a release maintenance branch as described in the [scaling up gideline](https://ibm.github.io/z-devops-acceleration-program/docs/git-branching-model-for-mainframe-dev/#scaling-up).
 * `Cleanup` stage: 
-  * to clean up project directory on Gitlab server
+  * to clean up project directory on Gitlab server, and
   * to [delete the build workspace](../Common-Backend-Scripts/README.md#411---deleteworkspacesh) on z/OS Unix System Services.
 
 Depending on your selected deployment technology, review the definitions and (de-)/activate the appropriate steps.

--- a/Templates/GitlabCIPipeline/README.md
+++ b/Templates/GitlabCIPipeline/README.md
@@ -39,7 +39,8 @@ The pipeline uses the Gitlab concepts: `Stage`and `Jobs`.
 
 To leverages this template, access to a Gitlab CI/CD environment is required, and an Gitlab runner must be configured to connect to your mainframe environment. Please review the setup instructions of this [document](https://www.ibm.com/support/pages/system/files/inline-files/Integrating%20IBM%20zOS%20platform%20in%20CICD%20pipelines%20with%20GitLab%20-%20v1.7_1.pdf).
 
-The template leverages the [Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli/) to issue command invoking the [Common Backend scripts](../Common-Backend-Scripts/) on USS.
+The template leverages [Zowe CLI](https://docs.zowe.org/stable/user-guide/cli-installcli/) to issue command invoking the [Common Backend scripts](../Common-Backend-Scripts/) on USS. It specifically uses the `issue unix-shell` command which allows streaming of the console outputs back the Zowe CLI task.
+
 * Zowe `base` and `rse` profiles needs to be configured in the `zowe.config.json` file under `.zowe` directory
 
     Example of Zowe configuration file:


### PR DESCRIPTION
This is enhancing the existing GitLab template with the following: 

* Leverage the `workflow` keyword to control the pipeline behaviour - see https://docs.gitlab.com/ee/ci/yaml/index.html#workflow
* Refactor the rules, when stages are executed
* Persist Wazi Deploy evidences for later reporting capabilities
* Move to `zowe rse issue unix-shell` that was released with IBM® RSE API Plug-in for Zowe CLI Version 4.2.0 on 16 March 2024, bringing a new option for long-running commands allowing a streaming of log output to the script that invokes it.


