### PR TITLE
PackageBuildOutputs creating delete manifest records for Wazi Deploy Application Manifest

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -441,7 +441,7 @@ if (rc == 0) {
 			} else if  (deployableArtifact.artifactType.equals("DatasetMemberDelete")) {
 					// generate delete instruction for Wazi Deploy
 					if (wdManifestGeneratorUtilities && props.generateWaziDeployAppManifest && props.generateWaziDeployAppManifest.toBoolean()) {
-						wdManifestGeneratorUtilities.appendArtifactDeletionToAppManifest(deployableArtifact, "$container/$fileName", record)
+						wdManifestGeneratorUtilities.appendArtifactDeletionToAppManifest(deployableArtifact, "$container/$fileName", record, propertiesRecord)
 					}
 			}
 

--- a/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
@@ -79,7 +79,7 @@ def appendArtifactToAppManifest(DeployableArtifact deployableArtifact, String pa
 def appendArtifactDeletionToAppManifest(DeployableArtifact deployableArtifact, String path, Record record){
 	Artifact artifact = new Artifact()
 	artifact.name = deployableArtifact.file
-	artifact.description = (record.file) ? record.file : deployableArtifact.file
+	artifact.description = (record.getAttribute("file")) ? record.getAttribute("file") : deployableArtifact.file
 	// Add properties
 	artifact.properties = new ArrayList()
 	ElementProperty pathProperty = new ElementProperty()
@@ -90,7 +90,7 @@ def appendArtifactDeletionToAppManifest(DeployableArtifact deployableArtifact, S
 	artifact.type = deployableArtifact.deployType
 
 	// adding artifact into applicationManifest
-	wdManifest.artifacts.add(artifact)
+	wdManifest.deleted_artifacts.add(artifact)
 }
 
 def setScmInfo(HashMap<String, String> scmInfoMap) {
@@ -112,6 +112,7 @@ def writeApplicationManifest(File yamlFile, String fileEncoding, String verbose)
 		kind wdManifest.kind
 		metadata wdManifest.metadata
 		artifacts  wdManifest.artifacts
+		deleted_artifacts wdManifest.deleted_artifacts
 	}
 
 	if (verbose && verbose.toBoolean()) {

--- a/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
@@ -17,6 +17,7 @@ import com.ibm.dbb.build.report.records.*
 def initWaziDeployManifestGenerator(Properties props) {
 	// Artifacts
 	wdManifest.artifacts = new ArrayList<Artifact>()
+	wdManifest.deleted_artifacts = new ArrayList<DeletedArtifact>()
 
 	// Metadata
 	wdManifest.metadata = new Metadata()
@@ -67,6 +68,26 @@ def appendArtifactToAppManifest(DeployableArtifact deployableArtifact, String pa
 	}
 	// add type
 	artifact.type =deployableArtifact.deployType
+
+	// adding artifact into applicationManifest
+	wdManifest.artifacts.add(artifact)
+}
+
+/**
+ *
+ */
+def appendArtifactDeletionToAppManifest(DeployableArtifact deployableArtifact, String path, Record record){
+	Artifact artifact = new Artifact()
+	artifact.name = deployableArtifact.file
+	artifact.description = (record.file) ? record.file : deployableArtifact.file
+	// Add properties
+	artifact.properties = new ArrayList()
+	ElementProperty pathProperty = new ElementProperty()
+	pathProperty.key = "path"
+	pathProperty.value = path
+	artifact.properties.add(pathProperty)
+	// add type
+	artifact.type = deployableArtifact.deployType
 
 	// adding artifact into applicationManifest
 	wdManifest.artifacts.add(artifact)
@@ -130,7 +151,7 @@ class WaziDeployManifest {
 	String kind = "ManifestState"
 	Metadata metadata
 	ArrayList<Artifact> artifacts
-
+	ArrayList<DeletedArtifact> deleted_artifacts
 }
 
 class Metadata {
@@ -167,6 +188,13 @@ class Artifact {
 	ArrayList<ElementProperty> properties
 	String type
 	String hash
+}
+
+class DeletedArtifact {
+	String name
+	String description
+	ArrayList<ElementProperty> properties
+	String type
 }
 
 class ElementProperty {


### PR DESCRIPTION
This is implementing the enhancement #265 .

This PR extends the existing logic and parses the `DELETE_RECORDS` created by zAppBuild, and injects them into the Wazi Deploy Application Manifest file under the `deleted_artifacts` group.