### PR TITLE
Enable common backend scripts to compute merge-base for feature branch pipelines

### DIFF
--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -211,7 +211,11 @@ gitClone.sh: [INFO] Clone Repository Complete. rc=0
 
 ### 4.2 - dbbBuild.sh
 
-This script implements the invocation of the [zAppBuild](https://github.com/IBM/dbb-zappbuild) framework. As designed, it makes use of the [baselineRef sub-option](https://github.com/IBM/dbb-zappbuild/blob/documentation-review/docs/BUILD.md#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files) provided by zAppBuild. The [dbbBuildUtils.sh](utilities/dbbBuildUtils.sh) script is used to compute the build configuration depending on the workflow to define zAppBuild CLI parameters. It leverages the [application baseline configuration](samples/baselineReference.config) file which is expected to be present in the `application-conf`` directory in order to compute the baseline reference and its changes.
+This script implements the invocation of the [zAppBuild](https://github.com/IBM/dbb-zappbuild) framework. 
+
+Per it's design it is following the recommended working practice. It makes use of the [baselineRef sub-option](https://github.com/IBM/dbb-zappbuild/blob/documentation-review/docs/BUILD.md#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files) provided by zAppBuild to set the baseline Git hash. This is used to identify all the merged changes for the upcoming deliverable (that can be a planned release, a emergency fix, or a significant development initiative)
+
+The computation of the build configuration is performed by the [dbbBuildUtils.sh](utilities/dbbBuildUtils.sh) script. It leverages the [application baseline configuration](samples/baselineReference.config) file which is expected to be present in the `application-conf` directory in order to compute the baseline reference.
 
 #### Git branches naming convention requirements
 
@@ -329,12 +333,16 @@ dbbBuild.sh: [INFO] DBB Build Complete. rc=0
 
 ### 4.3 - Script utility - dbbBuildUtils.sh
 
-The [dbbBuildUtils](utilities/dbbBuildUtils.sh) script is a utility script providing the `computeBuildConfiguration()` method to compute the zAppBuild's options and parameters:
+The [dbbBuildUtils](utilities/dbbBuildUtils.sh) script is a core utility script providing the `computeBuildConfiguration()` method to compute the zAppBuild's options and parameters according to the branch naming conventions. For instance
 
-* `build type`, such as `--impactBuild`
-* the baseline reference, `--baselineRef xxx`, where *xxx* is retrieved from the baselineReference.config file.
+* `build type`, such as the `--impactBuild` zAppBuild build option,
+  * the baseline reference, `--baselineRef xxx`, where *xxx* is retrieved from the baselineReference.config file for integration branches, 
+* the configured topic branch build behavior (see parameter `featureBranchBuildBehaviour` in pipelineBackend.config), that can either be configured as
+  * `merge-base` (default) for cumulative builds or all the changes added to the feature branch that flow to the integration branch. This setting automatically computes the merge-base commit, which defines the commit when the feature branch was forked.
+  * `incremental` for standard zAppBuild `--impactBuild` behavior.
+  * `cumulative` for computing all the differences between the topic branch and the integration branch by passing the `--baselineRef`. 
 * flag to produce test modules (`--debug` in zAppBuild) or modules improved for performance (production runtime modules).
-* the `mainBuildBranch` to configure feature branches to clone the correct dependency metadata collections and to identify the correct offset of changes.
+* the `mainBuildBranch` to configure feature branch pipelines to clone the corresponding DBB dependency metadata collections.
 
 #### Baseline references requirements
 

--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -338,7 +338,7 @@ The [dbbBuildUtils](utilities/dbbBuildUtils.sh) script is a core utility script 
 * `build type`, such as the `--impactBuild` zAppBuild build option,
   * the baseline reference, `--baselineRef xxx`, where *xxx* is retrieved from the baselineReference.config file for integration branches, 
 * the configured topic branch build behavior (see parameter `featureBranchBuildBehaviour` in pipelineBackend.config), that can either be configured as
-  * `merge-base` (default) for cumulative builds or all the changes added to the feature branch that flow to the integration branch. This setting automatically computes the merge-base commit, which defines the commit when the feature branch was forked.
+  * `merge-base` (default) for cumulative builds that include all the changes added to the feature branch that flow to the integration branch. This setting automatically computes the merge-base commit, which defines the commit when the feature branch was forked.
   * `incremental` for standard zAppBuild `--impactBuild` behavior.
   * `cumulative` for computing all the differences between the topic branch and the integration branch by passing the `--baselineRef`. 
 * flag to produce test modules (`--debug` in zAppBuild) or modules improved for performance (production runtime modules).

--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -213,7 +213,7 @@ gitClone.sh: [INFO] Clone Repository Complete. rc=0
 
 This script implements the invocation of the [zAppBuild](https://github.com/IBM/dbb-zappbuild) framework. 
 
-Per it's design it is following the recommended working practice. It makes use of the [baselineRef sub-option](https://github.com/IBM/dbb-zappbuild/blob/documentation-review/docs/BUILD.md#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files) provided by zAppBuild to set the baseline Git hash. This is used to identify all the merged changes for the upcoming deliverable (that can be a planned release, a emergency fix, or a significant development initiative)
+By design, the script implements the recommended working practice. It makes use of the [baselineRef sub-option](https://github.com/IBM/dbb-zappbuild/blob/documentation-review/docs/BUILD.md#perform-impact-build-by-providing-baseline-reference-for-the-analysis-of-changed-files) provided by zAppBuild to set the baseline Git hash. This is used to identify all the committed changes for the upcoming deliverable (that can be a planned release, a emergency fix, or a significant development initiative)
 
 The computation of the build configuration is performed by the [dbbBuildUtils.sh](utilities/dbbBuildUtils.sh) script. It leverages the [application baseline configuration](samples/baselineReference.config) file which is expected to be present in the `application-conf` directory in order to compute the baseline reference.
 

--- a/Templates/Common-Backend-Scripts/pipelineBackend.config
+++ b/Templates/Common-Backend-Scripts/pipelineBackend.config
@@ -88,10 +88,15 @@ dbbMetadataStoreJdbcPwdFile=""
 dbbMetadataStoreJdbcUrl=""
 
 # Feature branch build behaviour
-# options 
-# - "incremental" enables incremental builds for changed added to the feature branch
-# - "cumulative" enables cumulative builds with baselineRef option to build all contributed changes
-featureBranchBuildBehaviour=cumulative
+# options:
+# - "incremental" enables default zAppBuild impactBuild option. build list will contain only the
+#   changes that got added since the last successful build.
+# - "cumulative" enable impactBuild using the baselineRef option to build all contributed changes
+#   and any differences to the integration branch (main, release maintenance or epic)
+# - "merge-base" enables impactBuild using the baselineRef option. It passes the merge-base 
+#   commit. The dbbBuild utilities script computes the merge-base commit, which defines the commit
+#    when the feature branch was forked.
+featureBranchBuildBehaviour=merge-base
 
 #####################################################################################################
 ## End of DBB-BUILD.sh parameters    ################################################################


### PR DESCRIPTION
This is implementing #279 to use `git merge-base` to identify the point in the history when a topic branch was forked.

The new default behaviour for feature branch pipelines is to use the **merge-base** commit: In conjunction with zAppBuild, the result of this configuration is that feature branches pipelines will always identify all the changes added to the topic branch as changes, to build a consistent, cumulative preliminary package for the feature branch. 

Choosing this approach, there will be two options to deal with the process of integrating changes from main branch (or any other target) into the feature branch:

* `git merge` will commit all commits from main into the feature branch, and the merge-base strategy for computing the baseline commit hash will identify the existing changes of the feature branch and the new commits added to the feature branch via the merge operation.
* with `git rebase` updating the feature branch, the merge-base operation will no longer point to the initial fork-point for the feature branch but the new common ancestor commit, because commits on the feature branch are reapplied to the commit history of the base to the feature branch and define a new merge base. Using the approach, the build continues to identify only the changes added to the feature branch. 