### PR TITLE
Added support for OBJ artifacts and switched to IBM-1047 tags for YAML files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,8 @@
 *.skel zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.py zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.java zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
+*.yaml zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
+*.yml zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 
 # binary files
 *.png binary

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -28,7 +28,7 @@ addExtension=false
 # Boolean setting to define if the Wazi Deploy Application Manifest file should be generated
 #  Please note that the cli option `generateWaziDeployAppManifest` can override this setting and activate it.
 #  Default: false
-generateWaziDeployAppManifest=true
+generateWaziDeployAppManifest=false
 
 # Boolean setting to define if SBOM based on cycloneDX should be generated
 #  Please note that the cli option `generateSBOM` can override this setting and activate it.

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -5,7 +5,7 @@
 # required mapping of last level dataset qualifier to DBB CopyToFS CopyMode
 #  DBB supported copy modes are documented at
 #  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
-copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" : "BINARY"]
 
 # Comma-separated list of deployTypes to limit the scope of the tar
 # file to a subset of the build outputs. (Optional)
@@ -18,7 +18,7 @@ copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LO
 #  Please note that the cli option `includeLogs` overwrites this setting
 #  Sample: includeLogs = *.log,*.xml
 #
-# includeLogs = 
+# includeLogs =
 
 # Boolean setting to define if file the deployType should be added as the file extension
 #  Please note that the cli option `addExtension` can override this setting and activate it.
@@ -28,7 +28,7 @@ addExtension=false
 # Boolean setting to define if the Wazi Deploy Application Manifest file should be generated
 #  Please note that the cli option `generateWaziDeployAppManifest` can override this setting and activate it.
 #  Default: false
-generateWaziDeployAppManifest=false
+generateWaziDeployAppManifest=true
 
 # Boolean setting to define if SBOM based on cycloneDX should be generated
 #  Please note that the cli option `generateSBOM` can override this setting and activate it.


### PR DESCRIPTION
This PR adds a copy mode for artifacts that are in datasets OBJ (typically Object decks, which are meant to be copied as binary).
It also add an encoding for YAML files (either .yaml or .yml extensions).