### PR TITLE
Ability to publish interfaces via the tar file using the Application Descriptor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,8 @@
 *.skel zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.py zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 *.java zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
+*.yaml zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
+*.yml zos-working-tree-encoding=ibm-1047 git-encoding=utf-8
 
 # binary files
 *.png binary

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -273,7 +273,7 @@ props.buildReportOrder.each { buildReportFile ->
 							fileUsage = applicationDescriptorUtils.getFileUsageByType(applicationDescriptor, "Program", member)
 						}
 						// If the artifact is not an Object Deck or has no usage or its usage is not main
-						if ((output.deployType.equals("OBJ") && fileUsage && (fileUsage.equals("internal submodule")) || fileUsage.equals("service submodule")) ) || !output.deployType.equals("OBJ")) { 
+						if (((output.deployType.equals("OBJ") && fileUsage && (fileUsage.equals("internal submodule")) || fileUsage.equals("service submodule"))) || !output.deployType.equals("OBJ")) { 
 							datasetMembersCount++
 							String file = buildRecord.getFile()
 							def dependencySetRecord = buildReport.getRecords().find {

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -384,21 +384,10 @@ if (rc == 0) {
 					"tar -xUXf ${props.baselinePackageFilePath}"
 				]
 				
-				println("----- $tempLoadDir")
-		
 				def processRC = runProcess(processCmd, tempLoadDir)
 				rc = Math.max(rc, processRC)
 				if (rc == 0) {
 					println("** Baseline Package '${props.baselinePackageFilePath}' successfully extracted.")
-
-					processCmd = [
-						"sh",
-						"-c",
-						"ls -al"
-					]
-					processRC = runProcess(processCmd, tempLoadDir)
-
-
 
 					// Read the existing Wazi Deploy Manifest if any
 					if (props.generateWaziDeployAppManifest && props.generateWaziDeployAppManifest.toBoolean()) {

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -273,7 +273,7 @@ props.buildReportOrder.each { buildReportFile ->
 							fileUsage = applicationDescriptorUtils.getFileUsageByType(applicationDescriptor, "Program", member)
 						}
 						// If the artifact is not an Object Deck or has no usage or its usage is not main
-						if (((output.deployType.equals("OBJ") && fileUsage && (fileUsage.equals("internal submodule")) || fileUsage.equals("service submodule"))) || !output.deployType.equals("OBJ")) { 
+						if ((output.deployType.equals("OBJ") && fileUsage && (fileUsage.equals("internal submodule") || fileUsage.equals("service submodule"))) || !output.deployType.equals("OBJ")) { 
 							datasetMembersCount++
 							String file = buildRecord.getFile()
 							def dependencySetRecord = buildReport.getRecords().find {

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -122,7 +122,7 @@ HashMap<String,String> scmInfo = new HashMap<String, String>()
 
 // Package the public Include Files and service submodules
 // if Path to Application Descriptor file is specified
-if (props.publishInterfaces) {
+if (props.publishInterfaces && props.publishInterfaces.toBoolean()) {
 	File applicationDescriptorFile = new File("${props.applicationFolderPath}/applicationDescriptor.yml")
 	if (applicationDescriptorFile.exists()) {
 		applicationDescriptorUtils = loadScript(new File("utilities/applicationDescriptorUtils.groovy"))

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -522,22 +522,7 @@ if (rc == 0) {
 	
 			println("** Total number of build outputs to package: ${buildOutputsMap.size()}")
 
-			def publicInterfacesDeployTypes
-			def privateInterfacesDeployTypes
 			def processedArtifacts = 0 // used as a checksum that all files got categorized
-
-			if (props.publicInterfacesDeployTypes) {
-				publicInterfacesDeployTypes = props.publicInterfacesDeployTypes.split(",") // split comma separated list into list
-			} else {
-				println("*! [WARNING] Property 'publicInterfacesDeployTypes' not defined, using default types 'OBJ'.")
-				publicInterfacesDeployTypes = ["OBJ"]
-			}
-			if (props.privateInterfacesDeployTypes) {
-				privateInterfacesDeployTypes = props.privateInterfacesDeployTypes.split(",") // split comma separated list into list
-			} else {
-				println("*! [WARNING] Property 'privateInterfacesDeployTypes' not defined, using default types 'OBJ,BMSCOPY'.")
-				privateInterfacesDeployTypes = "OBJ,BMSCOPY".split(",")
-			}
 
 			def deployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
 				!((publicInterfacesDeployTypes && publicInterfacesDeployTypes.contains(deployableArtifact.deployType)) || (privateInterfacesDeployTypes && privateInterfacesDeployTypes.contains(deployableArtifact.deployType)))
@@ -549,6 +534,21 @@ if (rc == 0) {
 			}
 
 			if (props.publishInterfaces && props.publishInterfaces.toBoolean()) {
+				def publicInterfacesDeployTypes
+				def privateInterfacesDeployTypes
+				if (props.publicInterfacesDeployTypes) {
+					publicInterfacesDeployTypes = props.publicInterfacesDeployTypes.split(",") // split comma separated list into list
+				} else {
+					println("*! [WARNING] Property 'publicInterfacesDeployTypes' not defined, using default types 'OBJ'.")
+					publicInterfacesDeployTypes = ["OBJ"]
+				}
+				if (props.privateInterfacesDeployTypes) {
+					privateInterfacesDeployTypes = props.privateInterfacesDeployTypes.split(",") // split comma separated list into list
+				} else {
+					println("*! [WARNING] Property 'privateInterfacesDeployTypes' not defined, using default types 'OBJ,BMSCOPY'.")
+					privateInterfacesDeployTypes = "OBJ,BMSCOPY".split(",")
+				}
+
 				def publicInterfaces
 				if (publicInterfacesDeployTypes) {
 					// build outputs that are mapped to a public deployType and are flagged as 'service submodule' in the application descriptor

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -522,7 +522,22 @@ if (rc == 0) {
 	
 			println("** Total number of build outputs to package: ${buildOutputsMap.size()}")
 
+			def publicInterfacesDeployTypes
+			def privateInterfacesDeployTypes
 			def processedArtifacts = 0 // used as a checksum that all files got categorized
+
+			if (props.publicInterfacesDeployTypes) {
+				publicInterfacesDeployTypes = props.publicInterfacesDeployTypes.split(",") // split comma separated list into list
+			} else {
+				println("*! [WARNING] Property 'publicInterfacesDeployTypes' not defined, using default types 'OBJ'.")
+				publicInterfacesDeployTypes = ["OBJ"]
+			}
+			if (props.privateInterfacesDeployTypes) {
+				privateInterfacesDeployTypes = props.privateInterfacesDeployTypes.split(",") // split comma separated list into list
+			} else {
+				println("*! [WARNING] Property 'privateInterfacesDeployTypes' not defined, using default types 'OBJ,BMSCOPY'.")
+				privateInterfacesDeployTypes = "OBJ,BMSCOPY".split(",")
+			}
 
 			def deployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
 				!((publicInterfacesDeployTypes && publicInterfacesDeployTypes.contains(deployableArtifact.deployType)) || (privateInterfacesDeployTypes && privateInterfacesDeployTypes.contains(deployableArtifact.deployType)))
@@ -534,20 +549,6 @@ if (rc == 0) {
 			}
 
 			if (props.publishInterfaces && props.publishInterfaces.toBoolean()) {
-				def publicInterfacesDeployTypes
-				def privateInterfacesDeployTypes
-				if (props.publicInterfacesDeployTypes) {
-					publicInterfacesDeployTypes = props.publicInterfacesDeployTypes.split(",") // split comma separated list into list
-				} else {
-					println("*! [WARNING] Property 'publicInterfacesDeployTypes' not defined, using default types 'OBJ'.")
-					publicInterfacesDeployTypes = ["OBJ"]
-				}
-				if (props.privateInterfacesDeployTypes) {
-					privateInterfacesDeployTypes = props.privateInterfacesDeployTypes.split(",") // split comma separated list into list
-				} else {
-					println("*! [WARNING] Property 'privateInterfacesDeployTypes' not defined, using default types 'OBJ,BMSCOPY'.")
-					privateInterfacesDeployTypes = "OBJ,BMSCOPY".split(",")
-				}
 
 				def publicInterfaces
 				if (publicInterfacesDeployTypes) {

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -52,7 +52,7 @@ import com.ibm.jzos.ZFile;
  * Version 8 - 2024-07
  *  - Reworked error management and fixed few glitches
  *      
- * Version 9 - 2024-10
+ * Version 10 - 2024-11
  *  - Enhanced the packaging with the Application Descriptor file
  *    and baseline packages which allow full description of interfaces
  *      

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -383,11 +383,21 @@ if (rc == 0) {
 					"-c",
 					"tar -xUXf ${props.baselinePackageFilePath}"
 				]
+				
+				println("----- $tempLoadDir")
 		
 				def processRC = runProcess(processCmd, tempLoadDir)
 				rc = Math.max(rc, processRC)
 				if (rc == 0) {
 					println("** Baseline Package '${props.baselinePackageFilePath}' successfully extracted.")
+
+					processCmd = [
+						"sh",
+						"-c",
+						"ls -al"
+					]
+					processRC = runProcess(processCmd, tempLoadDir)
+
 
 
 					// Read the existing Wazi Deploy Manifest if any
@@ -432,8 +442,8 @@ if (rc == 0) {
 									}
 								}
 							}
+							subfolder.deleteDir()
 						}
-						subfolder.deleteDir()
 					}
 				} else {
 					println("*! [ERROR] Error when extracting baseline package '${created}' with rc=$rc.")

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -526,8 +526,18 @@ if (rc == 0) {
 			def privateInterfacesDeployTypes
 			def processedArtifacts = 0 // used as a checksum that all files got categorized
 
-			if (props.publicInterfacesDeployTypes) publicInterfacesDeployTypes = props.publicInterfacesDeployTypes.split(",") // split comma separated list into list
-			if (props.privateInterfacesDeployTypes) derivedInterfacesDeployTypes = props.privateInterfacesDeployTypes.split(",") // split comma separated list into list
+			if (props.publicInterfacesDeployTypes) {
+				publicInterfacesDeployTypes = props.publicInterfacesDeployTypes.split(",") // split comma separated list into list
+			} else {
+				println("*! [WARNING] Property 'publicInterfacesDeployTypes' not defined, using default types 'OBJ'.")
+				publicInterfacesDeployTypes = ["OBJ"]
+			}
+			if (props.privateInterfacesDeployTypes) {
+				privateInterfacesDeployTypes = props.privateInterfacesDeployTypes.split(",") // split comma separated list into list
+			} else {
+				println("*! [WARNING] Property 'privateInterfacesDeployTypes' not defined, using default types 'OBJ,BMSCOPY'.")
+				privateInterfacesDeployTypes = "OBJ,BMSCOPY".split(",")
+			}
 
 			def deployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
 				!((publicInterfacesDeployTypes && publicInterfacesDeployTypes.contains(deployableArtifact.deployType)) || (privateInterfacesDeployTypes && privateInterfacesDeployTypes.contains(deployableArtifact.deployType)))
@@ -1013,11 +1023,12 @@ def parseInput(String[] cliArgs){
 	if (opts.b) props.branch = opts.b
 
 	// cli overrides defaults set in 'packageBuildOutputs.properties'
-	props.generateWaziDeployAppManifest = (opts.wd) ? 'true' : props.generateWaziDeployAppManifest
-	props.generateConcertBuildManifest = (opts.ic) ? 'true' : props.generateConcertBuildManifest
-	props.addExtension = (opts.ae) ? 'true' : props.addExtension
-	props.publish = (opts.p) ? 'true' : props.publish
-	props.generateSBOM = (opts.sbom) ? 'true' : props.generateSBOM
+	props.generateWaziDeployAppManifest = (opts.wd) ? 'true' : (props.generateWaziDeployAppManifest ? props.generateWaziDeployAppManifest : 'false')
+	props.generateConcertBuildManifest = (opts.ic) ? 'true' : (props.generateConcertBuildManifest ? props.generateConcertBuildManifest : 'false')
+	props.addExtension = (opts.ae) ? 'true' : (props.addExtension ? props.addExtension : 'true')
+	props.publish = (opts.p) ? 'true' : (props.publish ? props.publish : 'false')
+	props.generateSBOM = (opts.sbom) ? 'true' : (props.generateSBOM ? props.generateSBOM : 'false')
+	props.publishInterfaces = (props.publishInterfaces ? props.publishInterfaces : 'false')
 
 	if (opts.o) props.owner = opts.o
 

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -378,7 +378,7 @@ props.buildReportOrder.each { buildReportFile ->
 				scmInfo.put("shortCommit", "multipleBuildReports")
 				scmInfo.put("uri", "multipleBuildReports")
 			}
-		}	
+		}
 	}
 }
 
@@ -1015,7 +1015,7 @@ def parseInput(String[] cliArgs){
 	// cli overrides defaults set in 'packageBuildOutputs.properties'
 	props.generateWaziDeployAppManifest = (opts.wd) ? 'true' : props.generateWaziDeployAppManifest
 	props.generateConcertBuildManifest = (opts.ic) ? 'true' : props.generateConcertBuildManifest
-	props.addExtension = (opts.ae) ? 'true' : ((props.addExtension) ? (props.addExtension) : 'true')
+	props.addExtension = (opts.ae) ? 'true' : props.addExtension
 	props.publish = (opts.p) ? 'true' : props.publish
 	props.generateSBOM = (opts.sbom) ? 'true' : props.generateSBOM
 

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -52,11 +52,7 @@ import com.ibm.jzos.ZFile;
  * Version 8 - 2024-07
  *  - Reworked error management and fixed few glitches
  *      
- *      
- *      
- *      
- *      
- * Version 10 - 2024-10
+ * Version 9 - 2024-10
  *  - Enhanced the packaging with the Application Descriptor file
  *    and baseline packages which allow full description of interfaces
  *      

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -624,7 +624,7 @@ if (rc == 0) {
 			}
 
 			if (processedArtifacts != buildOutputsMap.size()) {
-				println("*! [WARNING] The number of copied artifacts ($processedArtifacts) doesn't match the number of identified build outputs (${buildOutputsMap.size()}). Some files may not have an incorrect usage in the Application Descriptor.")
+				println("*! [WARNING] The number of copied artifacts ($processedArtifacts) doesn't match the number of identified build outputs (${buildOutputsMap.size()}). Some files might have an incorrect 'usage' in the Application Descriptor.")
 			}
 		}
 		

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -273,7 +273,7 @@ props.buildReportOrder.each { buildReportFile ->
 							fileUsage = applicationDescriptorUtils.getFileUsageByType(applicationDescriptor, "Program", member)
 						}
 						// If the artifact is not an Object Deck or has no usage or its usage is not main
-						if ((output.deployType.equals("OBJ") && fileUsage && !fileUsage.equals("main")) || !output.deployType.equals("OBJ")) { 
+						if ((output.deployType.equals("OBJ") && fileUsage && (fileUsage.equals("internal submodule")) || fileUsage.equals("service submodule")) ) || !output.deployType.equals("OBJ")) { 
 							datasetMembersCount++
 							String file = buildRecord.getFile()
 							def dependencySetRecord = buildReport.getRecords().find {

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -14,7 +14,7 @@ This sample Groovy script can be used to package build outputs:
   - It processes the MVSExec, CopyToPDS and the USS_Record types
 - It optionally generates the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file) file.
 - It copies outputs to a temporary directory on Unix System Services and creates a TAR file based on the temporary directory.
-- If the path to the application's Git repository is provided, the script will search for the Application Descriptor file, in order to also package all the public and shared Include Files. The script will also detect which programs are classified as `internal submodule` or `service submodule` and will copy the corresponding object decks to the `include`subfolder of the temporary directory.
+- If the path to the application's Git repository is provided, the script will search for the Application Descriptor file and process it. Include Files classified as `public` will be automatically added to the package into the subdirectory `include/src`. The script will also process programs that are classified as `internal submodule` or `service submodule` and will copy the corresponding object decks to either the `lib` directory or the `include/bin` subfolder for the tar file.
 - If a baseline package is provided through the corresponding CLI option, the baseline package is expanded in the temporary directory first:
   - All the subfolders are removed except the subfolder that contains interfaces definitions, by default located in the `include` subfolder.
   - More information can be found in the [Baseline Packages](#baseline-packages) section.

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -42,7 +42,7 @@ This section provides a more detailed explanation of how the PackageBuildOutputs
    More details can be found [in this section](#software-bill-of-material-sbom-generation).
 
 4. **(Optionally) Generate Wazi Deploy application manifest**
-   Based on the collected build outputs information, the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file) is generated and saved as wazideploy_manifest.yml.
+   Based on the collected build outputs information, the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/17.0?topic=files-application-manifest-file) is generated and saved as wazideploy_manifest.yml.
 
 5. **Create TAR file**
     1. It then invokes CopyToHFS API to copy the outputs from the libraries to a temporary directory on zFS. It will set the file tags based on the ZLANG setting (Note: A workaround is implemented to tag files as binary); all files require to be tagged. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS. When specifying the option `--addExtension`, the `deployType` will be appended as the file extension to the file.

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -5,14 +5,19 @@
 This sample shows how to create a TAR file with the build outputs based on the DBB Build Report after a successful build.
 
 The package can be uploaded to an artifact repository and used in a scripted deployment. Another area, where this script is beneficial as a sample, is to adapt this script in publishing shared copybooks to an artifact repository and to pull them into the build process. The `ArtifactRepositoryHelpers.groovy` allow you to upload and download packages from Artifactory. 
-The `ArtifactRepositoryHelpers` script is a very simple implementation sufficient for a show case, **_we recommend_** to use the Artifactory publishers which are available with your CI pipeline coordinator.
+The `ArtifactRepositoryHelpers` script is a simple implementation to support download and upload from/to an Artifact Repository server.
+However, it is recommend to consider using APIs or CLI utilities provided by Artifact Repositories distributions, which are available with your CI/CD pipeline coordinator.
 
-This sample Groovy script to package build outputs:
+This sample Groovy script can be used to package build outputs:
 
-- Extracts information about the build outputs from the Dependency Based Build (DBB) `BuildReport.json`. The script is able to take a single DBB build report or multiple build reports to build a cumulative package across multiple incremental builds. 
+- It extracts information about the build outputs from the Dependency Based Build (DBB) `BuildReport.json`. The script is able to take a single DBB build report or multiple build reports to build a cumulative package across multiple incremental builds. 
   - It processes the MVSExec, CopyToPDS and the USS_Record types
-- (Optionally) generates the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file) file.
-- Copies outputs to a temporary directory on Unix System Services and creates a TAR file based on the temporary directory.
+- It optionally generates the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file) file.
+- It copies outputs to a temporary directory on Unix System Services and creates a TAR file based on the temporary directory.
+- If the path to the application's Git repository is provided, the script will search for the Application Descriptor file, in order to also package all the public and shared Include Files. The script will also detect which programs are classified as `internal submodule` or `service submodule` and will copy the corresponding object decks to the `include`subfolder of the temporary directory.
+- If a baseline package is provided through the corresponding CLI option, the baseline package is expanded in the temporary directory first:
+  - All the subfolders are removed except the subfolder that contains interfaces definitions, by default located in the `include` subfolder.
+  - More information can be found in the [Baseline Packages](#baseline-packages) section.
 
 The support for zFS files in the packaging process is performed through the use of an `USS_RECORD` type record in the DBB BuildReport. 
 
@@ -22,26 +27,27 @@ This section provides a more detailed explanation of how the PackageBuildOutputs
 
 1. **Initialization**
    1. Read [command line parameters](#command-line-options-summary---packagebuildoutputs).
-   1. Read the properties file that is passed via `--packagingPropertiesFile`.
+   2. Read the properties file that is passed via `--packagingPropertiesFile`.
 
 2. **Process the DBB build report(s)**
    1. If one or multiple DBB build reports are passed to the script via either `--buildReportOrder` or `--buildReportOrderFile`, the script loops through the provided DBB build reports. If no build report is specified, the script reads DBB's `BuildReport.json` file from the pipeline work directory specified by the `--workDir` parameter. For each build report, the following steps are performed:
-      1. Parse and extract build output information for records of type *ExecuteRecord* and *CopyToPDSRecord*.
+      1. Parse and extract build output information for records of type *ExecuteRecord*, *CopyToPDSRecord* and *USS_Record*.
       2. Remove output entries that have no `deployType` set and remove unwanted outputs such as outputs with the `deployType` equal to `ZUNIT-TESTCASE`.
    2. If processing multiple build reports, a cumulative hashmap of output records is created to be able to combine outputs from multiple pipeline builds into a single TAR file.
    	  1. The key of the map, used in the calculation of the artifacts to be deployed, is the combination of the member name and the deploy type.
    	  2. Artifacts having the same member name and the same deploy type will be present only once in the generated package, taking the last occurrence of the artifact, as found in the ordered list of Build Reports passed as parameters.
 
 3. **(Optionally) Generate Software-Bill-Of-Material (SBOM) file**
-   1. Based on the collected build outputs information, an SBOM file following the [CycloneDX](https://cyclonedx.org/) specification is created.  
+   Based on the collected build outputs information, an SBOM file following the [CycloneDX](https://cyclonedx.org/) specification is created.  
    More details can be found [in this section](#software-bill-of-material-sbom-generation).
 
 4. **(Optionally) Generate Wazi Deploy application manifest**
-   1. Based on the collected build outputs information, the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file) is generated and saved as wazideploy_manifest.yml.
+   Based on the collected build outputs information, the [Wazi Deploy application manifest](https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file) is generated and saved as wazideploy_manifest.yml.
 
 5. **Create TAR file**
     1. It then invokes CopyToHFS API to copy the outputs from the libraries to a temporary directory on zFS. It will set the file tags based on the ZLANG setting (Note: A workaround is implemented to tag files as binary); all files require to be tagged. Please check the COPYMODE list, which maps last level qualifiers to the copymode of CopyToHFS. When specifying the option `--addExtension`, the `deployType` will be appended as the file extension to the file.
     2. It packages these load files into a TAR file, and adds the BuildReport.json and optionally other build logs from the build workspace.
+    3. If the path to th application's Git repository is provided, it will copy the Include Files classfified as public and shared into the `include` subfolder of tge temporary directory.
 
 6. **(Optional) Publish to Artifact Repository such as JFrog Artifactory or Sonartype Nexus**
     1. Publishes the TAR file to the artifact repository based on the given configuration using the ArtifactRepositoryHelpers script. Consider a Nexus RAW, or a Artifactory Generic as the repository type. **Please note**: The ArtifactRepositoryHelpers script is updated for DBB 2.0 and requires to run on JAVA 11. The publishing can be configured to pass in the artifact repository information as well as the path within the repository `directory/[versionName|buildLabel]/tarFileName` via the cli.
@@ -53,8 +59,8 @@ Notes:
 
 ### Package
 ```
-groovyz /var/pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \ 
-        --workDir /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949
+groovyz /var/pipeline/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator
+
 ```
 
 <details>
@@ -63,42 +69,37 @@ groovyz /var/pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \
 PackageBuildOutputs console output
 
 ```
-** PackageBuildOutputs start at 20220901.025517.055
+** PackageBuildOutputs start at 20241028.145508.011
 ** Properties at startup:
-   verbose -> false
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD"]
-   packagingPropertiesFile -> /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties
-   startTime -> 20220901.025517.055
-   publish -> false
-   workDir -> /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949
-   buildReportOrder -> [/u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json]
    addExtension -> false
-** Read build report data from /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
-** Files detected in /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMORT), MAPLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIS), MAPLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRT), CICSLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMPMT), LOAD
-   GITLAB.ZAPP.CLEAN.MAIN.DBRM(EPSCMORT), DBRM
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCMORT), CICSLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRD), CICSLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIST), CICSLOAD
-*** Number of build outputs to package: 8
-** Copying BuildOutputs to temporary package dir.
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSCSMRT with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRD) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSCSMRD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMORT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMORT with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMPMT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMPMT with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIST) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMLIST with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIS) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMLIS with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCMORT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSCMORT with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.DBRM(EPSCMORT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.DBRM/EPSCMORT with DBB Copymode BINARY
-** Copying /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json to temporary package dir.
-** Copying /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/build.20220614.084654.046.tar.
-** Package successfully created at /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/build.20220614.084654.046.tar.
-
+   buildReportOrder -> [/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json]
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" : "BINARY"]
+   fileEncoding -> UTF-8
+   generateSBOM -> false
+   generateWaziDeployAppManifest -> false
+   packagingPropertiesFile -> /u/mdalbin/dbb-MD/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   publish -> false
+   startTime -> 20241028.145508.011
+   verbose -> false
+   workDir -> /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator
+** Read build report data from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json'.
+** Remove output records without deployType or with deployType=ZUNIT-TESTCASE
+** Deployable artifacts detected in '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json':
+        'EBUD03' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD02' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD0RUN' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD01' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+*** Number of build outputs to package: 4
+** Copy build outputs to temporary package directory '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir'
+        Copy 'DBEHM.MIG.LOAD(EBUD03)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD03' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD02)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD02' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD0RUN)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD0RUN' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD01)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD01' with DBB Copymode 'LOAD'
+** Generate package build report order file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/buildReportOrder.txt'
+** Copy packaging properties config file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/packageBuildOutputs.properties'
+** Create tar file at /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar
+** Package '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar' successfully created.
+** Packaging completed successfully.
 ```
 </details>
 
@@ -107,9 +108,7 @@ PackageBuildOutputs console output
 Adding `--addExtension` is mandatory, when you plan to use Wazi Deploy as the deployment engine.
 
 ```
-+ groovyz /var/pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \
-        --workDir /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949 \
-        --addExtension
+groovyz /var/pipeline/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy --workDir /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator --addExtension
 ```
 
 <details>
@@ -118,44 +117,39 @@ Adding `--addExtension` is mandatory, when you plan to use Wazi Deploy as the de
 PackageBuildOutputs console output
 
 ```
-
-** PackageBuildOutputs start at 20220901.025846.058
+** PackageBuildOutputs start at 20241028.145001.451
 ** Properties at startup:
-   verbose -> false
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD"]
-   packagingPropertiesFile -> /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties
-   startTime -> 20220901.025846.058
-   publish -> false
-   workDir -> /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949
-   buildReportOrder -> [/u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json]
    addExtension -> true
-** Read build report data from /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
-** Files detected in /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMORT), MAPLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIS), MAPLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRT), CICSLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMPMT), LOAD
-   GITLAB.ZAPP.CLEAN.MAIN.DBRM(EPSCMORT), DBRM
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCMORT), CICSLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRD), CICSLOAD
-   GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIST), CICSLOAD
-*** Number of build outputs to package: 8
-** Copying BuildOutputs to temporary package dir.
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSCSMRT.CICSLOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCSMRD) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSCSMRD.CICSLOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMORT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMORT.MAPLOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMPMT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMPMT.LOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIST) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMLIST.CICSLOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSMLIS) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSMLIS.MAPLOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.LOAD(EPSCMORT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.LOAD/EPSCMORT.CICSLOAD with DBB Copymode LOAD
-     Copying GITLAB.ZAPP.CLEAN.MAIN.DBRM(EPSCMORT) to /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/tempPackageDir/GITLAB.ZAPP.CLEAN.MAIN.DBRM/EPSCMORT.DBRM with DBB Copymode BINARY
-** Copying /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/BuildReport.json to temporary package dir.
-** Copying /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/build.20220614.084654.046.tar.
-** Package successfully created at /u/gitlab/gitlab-runner/zos/builds/dbb-zappbuild/BUILD-5949/build.20220614.084654.046.tar.
-
+   buildReportOrder -> [/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json]
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" : "BINARY"]
+   fileEncoding -> UTF-8
+   generateSBOM -> false
+   generateWaziDeployAppManifest -> false
+   packagingPropertiesFile -> /u/mdalbin/dbb-MD/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   publish -> false
+   startTime -> 20241028.145001.451
+   verbose -> false
+   workDir -> /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator
+** Read build report data from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json'.
+** Remove output records without deployType or with deployType=ZUNIT-TESTCASE
+** Deployable artifacts detected in '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json':
+        'EBUD03' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD02' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD0RUN' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD01' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+*** Number of build outputs to package: 4
+** Copy build outputs to temporary package directory '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir'
+        Copy 'DBEHM.MIG.LOAD(EBUD03)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD03.LOAD' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD02)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD02.LOAD' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD0RUN)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD0RUN.LOAD' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD01)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD01.LOAD' with DBB Copymode 'LOAD'
+** Generate package build report order file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/buildReportOrder.txt'
+** Copy packaging properties config file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/packageBuildOutputs.properties'
+** Create tar file at /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar
+** Package '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar' successfully created.
+** Packaging completed successfully.
 ```
+
 </details>
 
 ### Package to deploy with Wazi Deploy
@@ -166,10 +160,11 @@ When deploying with Wazi Deploy, and generating the Wazi Deploy Application Mani
 * `--addExtension`
 * `--branch`
 * `--versionName` (recommended)
+* `--application` (recommended)
 
 ```
-+ groovyz /var/pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \
-      --workDir /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs  \
++ groovyz /var/pipeline/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \
+      --workDir /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator  \
       --tarFileName retirementCalculator.tar  \
       --application retirementCalculator  \
       --addExtension \
@@ -186,30 +181,44 @@ When deploying with Wazi Deploy, and generating the Wazi Deploy Application Mani
 PackageBuildOutputs console output
 
 ```
-** PackageBuildOutputs start at 20240304.015055.050
+** PackageBuildOutputs start at 20241028.145841.890
 ** Properties at startup:
    addExtension -> true
    application -> retirementCalculator
    branch -> main
-   buildReportOrder -> [/u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/BuildReport.json]
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+   buildReportOrder -> [/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json]
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" :
+"BINARY"]
+   fileEncoding -> UTF-8
+   generateSBOM -> false
    generateWaziDeployAppManifest -> true
    includeLogs -> *.log
-   packagingPropertiesFile -> /u/pipeline/git/dbb/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   packagingPropertiesFile -> /u/mdalbin/dbb-MD/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
    publish -> false
-   startTime -> 20240304.015055.050
+   startTime -> 20241028.145841.890
    tarFileName -> retirementCalculator.tar
    verbose -> true
    versionName -> rel-2.0.0
-   workDir -> /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs
-** Read build report data from /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/BuildReport.json.
-** Removing output records w/o deployType or with deployType=ZUNIT-TESTCASE
-** Deployable files detected in /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/BuildReport.json
-   ADO.RETIREME.MAIN.BLD.LOAD(EBUD01), LOAD
-*** Number of build outputs to package: 1
-** Copying build outputs to temporary package directory /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/tempPackageDir
-   Copy ADO.RETIREME.MAIN.BLD.LOAD(EBUD01) to /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/tempPackageDir/ADO.RETIREME.MAIN.BLD.LOAD/EBUD01.LOAD with DBB Copymode LOAD
-** Generate Wazi Deploy Application Manifest file to /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/tempPackageDir/wazideploy_manifest.yml
+   workDir -> /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator
+** Read build report data from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json'.
+** Remove output records without deployType or with deployType=ZUNIT-TESTCASE
+** Deployable artifacts detected in '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json':
+        'EBUD03' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD02' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD0RUN' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD01' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+*** Number of build outputs to package: 4
+** Copy build outputs to temporary package directory '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir'
+        Copy 'DBEHM.MIG.LOAD(EBUD03)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD
+03.LOAD' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD02)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD
+02.LOAD' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD0RUN)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EB
+UD0RUN.LOAD' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD01)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD
+01.LOAD' with DBB Copymode 'LOAD'
+** Generate Wazi Deploy Application Manifest file to /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/wa
+zideploy_manifest.yml
 ---
 apiVersion: "wazideploy.ibm.com/v1"
 kind: "ManifestState"
@@ -218,55 +227,87 @@ metadata:
   description: "retirementCalculator"
   version: "rel-2.0.0"
   annotations:
-    creationTimestamp: "20240304.015055.050"
+    creationTimestamp: "20241028.145841.890"
     scmInfo:
       type: "git"
-      uri: "git@ssh.dev.azure.com:v3/IBM-DAT/retirementCalculator/retirementCalculator"
+      uri: null
       branch: "main"
-      shortCommit: "cac60e95685575fab15a583d2a3966a087b58b38"
+      shortCommit: "581f315a70a69454fcd880b6c3a4bb59f991414d"
     packageInfo: null
 artifacts:
-- name: "EBUD01"
-  description: "retirementCalculator/cobol/EBUD01.cbl"
+- name: "EBUD03"
+  description: "RetirementCalculator/src/cobol/ebud03.cbl"
   properties:
+  - key: "path"
+    value: "bin/LOAD/EBUD03.LOAD"
   - key: "githash"
-    value: "cac60e95685575fab15a583d2a3966a087b58b38"
-  - key: "giturl"
-    value: "git@ssh.dev.azure.com:v3/IBM-DAT/retirementCalculator/retirementCalculator"
+    value: "581f315a70a69454fcd880b6c3a4bb59f991414d"
   type: "LOAD"
-  hash: "cac60e95685575fab15a583d2a3966a087b58b38"
+  hash: "581f315a70a69454fcd880b6c3a4bb59f991414d"
+- name: "EBUD02"
+  description: "RetirementCalculator/src/cobol/ebud02.cbl"
+  properties:
+  - key: "path"
+    value: "bin/LOAD/EBUD02.LOAD"
+  - key: "githash"
+    value: "581f315a70a69454fcd880b6c3a4bb59f991414d"
+  type: "LOAD"
+  hash: "581f315a70a69454fcd880b6c3a4bb59f991414d"
+- name: "EBUD0RUN"
+  description: "RetirementCalculator/src/cobol/ebud0run.cbl"
+  properties:
+  - key: "path"
+    value: "bin/LOAD/EBUD0RUN.LOAD"
+  - key: "githash"
+    value: "581f315a70a69454fcd880b6c3a4bb59f991414d"
+  type: "LOAD"
+  hash: "581f315a70a69454fcd880b6c3a4bb59f991414d"
+- name: "EBUD01"
+  description: "RetirementCalculator/src/cobol/ebud01.cbl"
+  properties:
+  - key: "path"
+    value: "bin/LOAD/EBUD01.LOAD"
+  - key: "githash"
+    value: "581f315a70a69454fcd880b6c3a4bb59f991414d"
+  type: "LOAD"
+  hash: "581f315a70a69454fcd880b6c3a4bb59f991414d"
 
-** Generate package build report order file to /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/tempPackageDir/buildReportOrder.txt
-** Copy packaging properties config file to /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/tempPackageDir/packageBuildOutputs.properties
-** Creating tar file at /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/retirementCalculator.tar
-   Executing [sh, -c, tar cUXf /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/retirementCalculator.tar *]
-** Package successfully created at /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/retirementCalculator.tar
-** Adding files with file pattern *.log from /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs to /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/retirementCalculator.tar
-   Executing [sh, -c, tar rUXf /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/retirementCalculator.tar *.log]
+** Generate package build report order file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/buildRe
+portOrder.txt'
+** Copy packaging properties config file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/packageBui
+ldOutputs.properties'
+** Create tar file at /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/retirementCalculator.tar
+   Executing [sh, -c, tar cUXf /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/retirementCalculator.tar *]
+** Package '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/retirementCalculator.tar' successfully created.
+** Add files with file pattern '*.log' from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator' to '/u/mdalbin/Migration
+-Modeler-MDLB-work/logs/RetirementCalculator/retirementCalculator.tar'
+   Executing [sh, -c, tar rUXf /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/retirementCalculator.tar *.log]
 ** List package contents.
-   Executing [sh, -c, tar tvf /u/ado/workspace/retirementCalculator/main/build-20240215.5/logs/retirementCalculator.tar]
-drwxr-xr-x   1 BPXROOT  TIVUSR         0 Mar  4 13:50 ADO.RETIREME.MAIN.BLD.LOAD/
--rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Mar  4 13:50 ADO.RETIREME.MAIN.BLD.LOAD/EBUD01.LOAD
--rw-r--r--   1 ADO      TIVUSR      4239 Feb 15 10:19 BuildReport.json
--rw-r--r--   1 BPXROOT  TIVUSR        97 Mar  4 13:50 buildReportOrder.txt
--rw-r--r--   1 BPXROOT  TIVUSR      1515 Mar  1 17:54 packageBuildOutputs.properties
--rw-r--r--   1 BPXROOT  TIVUSR       790 Mar  4 13:50 wazideploy_manifest.yml
--rw-r--r--   1 ADO      TIVUSR    121483 Feb 15 10:19 EBUD01.cobol.log
--rw-r--r--   1 ADO      TIVUSR       115 Feb 15 10:19 externalImpacts_MortgageApplication-feature%2FconsumeRetirementCalculatorService.log
+   Executing [sh, -c, tar tvf /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/retirementCalculator.tar]
+-rw-rw-rw-   1 BPXROOT  TIVUSR      9169 Oct 28 11:29 001_BuildReport.json
+drwxr-xr-x   1 BPXROOT  TIVUSR         0 Oct 28 14:58 bin/
+drwxr-xr-x   1 BPXROOT  TIVUSR         0 Oct 28 14:58 bin/LOAD/
+-rwxr-xr-x   1 BPXROOT  TIVUSR     86016 Oct 28 14:58 bin/LOAD/EBUD03.LOAD
+-rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Oct 28 14:58 bin/LOAD/EBUD02.LOAD
+-rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Oct 28 14:58 bin/LOAD/EBUD0RUN.LOAD
+-rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Oct 28 14:58 bin/LOAD/EBUD01.LOAD
+-rw-r--r--   1 BPXROOT  TIVUSR        22 Oct 28 14:58 buildReportOrder.txt
+-rw-r--r--   1 BPXROOT  ZSECURE     2502 Oct 28 14:54 packageBuildOutputs.properties
+-rw-r--r--   1 BPXROOT  TIVUSR      1509 Oct 28 14:58 wazideploy_manifest.yml
+-rw-r--r--   1 BPXROOT  TIVUSR      2296 Oct 18 16:38 build-preview-RetirementCalculator.log
+-rw-r--r--   1 BPXROOT  TIVUSR      4411 Oct 18 16:38 packaging-preview-RetirementCalculator.log
 
-** PackageBuildOutputs.groovy completed successfully
-** Build finished
+** Packaging completed successfully.
 ```
 </details>
 
 ### Package using multiple build reports
 
 ```
-+ groovyz /var/pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \
-        --workDir /var/pipeline/work \
-        --buildReportOrder /var/pipeline/retirementCalculator/BuildReport_1.json,/var/pipeline/retirementCalculator/BuildReport_2.json \
-        --tarFileName rel-1.0.0.tar \
-        --packagingPropertiesFile /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties \
++ groovyz /var/pipeline/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy \
+        --workDir /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator \
+        --buildReportOrder /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/previous_BuildReport.json,/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/last_BuildReport.json \
+        --tarFileName rel-1.2.0.tar \
         --verbose
 ```
 
@@ -276,64 +317,61 @@ drwxr-xr-x   1 BPXROOT  TIVUSR         0 Mar  4 13:50 ADO.RETIREME.MAIN.BLD.LOAD
 PackageBuildOutputs console output
 
 ```
-
-** PackageBuildOutputs start at 20220901.030431.004
+** PackageBuildOutputs start at 20241028.150801.393
 ** Properties at startup:
-   workDir -> /var/pipeline/work
-   startTime -> 20220901.030431.004
-   publish -> false
-   verbose -> true
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "COBOL":"TEXT"]
-   packagingPropertiesFile -> /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties
-   buildReportOrder -> [/var/pipeline/retirementCalculator/BuildReport_1.json, /var/pipeline/retirementCalculator/BuildReport_2.json]
    addExtension -> false
-   tarFileName -> rel-1.0.0.tar
-** Read build report data from /var/pipeline/retirementCalculator/BuildReport_1.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
-**  Files detected in /var/pipeline/retirementCalculator/BuildReport_1.json
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD01), LOAD
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD03), LOAD
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD0RUN), LOAD
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD02), LOAD
-** Read build report data from /var/pipeline/retirementCalculator/BuildReport_2.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
-**  Files detected in /var/pipeline/retirementCalculator/BuildReport_2.json
-   JENKINS.ZDAT.RETIRE.COPY(LINPUT), COPY
-   JENKINS.ZDAT.RETIRE.LOAD(EBUD02), CICSLOAD
-   JENKINS.ZDAT.RETIRE.COBOL(EBUD02), COBOL
-*** Number of build outputs to package: 6
-** Copying BuildOutputs to temporary package dir.
-     Copying JENKINS.ZDAT.RETIRE.LOAD(EBUD0RUN) to /var/pipeline/work/tempPackageDir/JENKINS.ZDAT.RETIRE.LOAD/EBUD0RUN with DBB Copymode LOAD
-     Copying JENKINS.ZDAT.RETIRE.LOAD(EBUD02) to /var/pipeline/work/tempPackageDir/JENKINS.ZDAT.RETIRE.LOAD/EBUD02 with DBB Copymode LOAD
-     Copying JENKINS.ZDAT.RETIRE.LOAD(EBUD03) to /var/pipeline/work/tempPackageDir/JENKINS.ZDAT.RETIRE.LOAD/EBUD03 with DBB Copymode LOAD
-     Copying JENKINS.ZDAT.RETIRE.LOAD(EBUD01) to /var/pipeline/work/tempPackageDir/JENKINS.ZDAT.RETIRE.LOAD/EBUD01 with DBB Copymode LOAD
-     Copying JENKINS.ZDAT.RETIRE.COBOL(EBUD02) to /var/pipeline/work/tempPackageDir/JENKINS.ZDAT.RETIRE.COBOL/EBUD02 with DBB Copymode TEXT
-     Copying JENKINS.ZDAT.RETIRE.COPY(LINPUT) to /var/pipeline/work/tempPackageDir/JENKINS.ZDAT.RETIRE.COPY/LINPUT with DBB Copymode TEXT
-** Copying /var/pipeline/retirementCalculator/BuildReport_1.json to temporary package dir as 001_BuildReport_1.json. Executing [sh, -c, cp /var/pipeline/retirementCalculator/BuildReport_1.json /var/pipeline/work/tempPackageDir/001_BuildReport_1.json]:
-** Copying /var/pipeline/retirementCalculator/BuildReport_2.json to temporary package dir as 002_BuildReport_2.json. Executing [sh, -c, cp /var/pipeline/retirementCalculator/BuildReport_2.json /var/pipeline/work/tempPackageDir/002_BuildReport_2.json]:
-** Copying /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties to temporary package dir.executing [sh, -c, cp /var/pipeline/PackageBuildOutputs/packageBuildOutputs.properties /var/pipeline/work/tempPackageDir]:
-** Creating tar file at /var/pipeline/work/rel-1.0.0.tar.
-executing [sh, -c, tar cUXf /var/pipeline/work/rel-1.0.0.tar *]:
+   buildReportOrder -> [/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/previous_BuildReport.json, /u/mdalbin/Migratio
+n-Modeler-MDLB-work/logs/RetirementCalculator/last_BuildReport.json]
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" :
+"BINARY"]
+   fileEncoding -> UTF-8
+   generateSBOM -> false
+   generateWaziDeployAppManifest -> false
+   packagingPropertiesFile -> /u/mdalbin/dbb-MD/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+   publish -> false
+   startTime -> 20241028.150801.393
+   tarFileName -> rel-1.2.0.tar
+   verbose -> true
+   workDir -> /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator
+** Read build report data from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/previous_BuildReport.json'.
+** Remove output records without deployType or with deployType=ZUNIT-TESTCASE
+** Deployable artifacts detected in '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/previous_BuildReport.json':
+        'EBUD03' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD02' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD0RUN' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD01' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+** Read build report data from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/last_BuildReport.json'.
+** Remove output records without deployType or with deployType=ZUNIT-TESTCASE
+** Deployable artifacts detected in '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/last_BuildReport.json':
+        'EBUD03' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD02' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD0RUN' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD01' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+*** Number of build outputs to package: 4
+** Copy build outputs to temporary package directory '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir'
+        Copy 'DBEHM.MIG.LOAD(EBUD03)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD03' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD02)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD02' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD0RUN)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD0RUN' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD01)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD01' with DBB Copymode 'LOAD'
+** Generate package build report order file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/buildReportOrder.txt'
+** Copy packaging properties config file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/packageBuildOutputs.properties'
+** Create tar file at /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/rel-1.2.0.tar
+   Executing [sh, -c, tar cUXf /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/rel-1.2.0.tar *]
+** Package '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/rel-1.2.0.tar' successfully created.
+** List package contents.
+   Executing [sh, -c, tar tvf /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/rel-1.2.0.tar]
+-rw-------   1 BPXROOT  TIVUSR      9888 Oct 18 16:38 001_previous_BuildReport.json
+-rw-rw-rw-   1 BPXROOT  TIVUSR      9169 Oct 28 11:29 002_last_BuildReport.json
+drwxr-xr-x   1 BPXROOT  TIVUSR         0 Oct 28 15:08 bin/
+drwxr-xr-x   1 BPXROOT  TIVUSR         0 Oct 28 15:08 bin/LOAD/
+-rwxr-xr-x   1 BPXROOT  TIVUSR     86016 Oct 28 15:08 bin/LOAD/EBUD03
+-rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Oct 28 15:08 bin/LOAD/EBUD02
+-rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Oct 28 15:08 bin/LOAD/EBUD0RUN
+-rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Oct 28 15:08 bin/LOAD/EBUD01
+-rw-r--r--   1 BPXROOT  TIVUSR        58 Oct 28 15:08 buildReportOrder.txt
+-rw-r--r--   1 BPXROOT  ZSECURE     2502 Oct 28 14:54 packageBuildOutputs.properties
 
-** Package successfully created at /var/pipeline/work/rel-1.0.0.tar.
-**   List package contents.
-executing [sh, -c, tar tvf /var/pipeline/work/rel-1.0.0.tar]:
--rw-------   1 BPXROOT  TIVUSR     22489 Sep  1 16:04 001_BuildReport_1.json
--rw-------   1 BPXROOT  TIVUSR     18708 Sep  1 16:04 002_BuildReport_2.json
-drwxr-xr-x   1 BPXROOT  TIVUSR         0 Sep  1 16:04 JENKINS.ZDAT.RETIRE.COBOL/
--rw-r--r--   1 BPXROOT  TIVUSR      2107 Sep  1 16:04 JENKINS.ZDAT.RETIRE.COBOL/EBUD02
-drwxr-xr-x   1 BPXROOT  TIVUSR         0 Sep  1 16:04 JENKINS.ZDAT.RETIRE.COPY/
--rw-r--r--   1 BPXROOT  TIVUSR       333 Sep  1 16:04 JENKINS.ZDAT.RETIRE.COPY/LINPUT
-drwxr-xr-x   1 BPXROOT  TIVUSR         0 Sep  1 16:04 JENKINS.ZDAT.RETIRE.LOAD/
--rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Sep  1 16:04 JENKINS.ZDAT.RETIRE.LOAD/EBUD0RUN
--rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Sep  1 16:04 JENKINS.ZDAT.RETIRE.LOAD/EBUD02
--rwxr-xr-x   1 BPXROOT  TIVUSR     86016 Sep  1 16:04 JENKINS.ZDAT.RETIRE.LOAD/EBUD03
--rwxr-xr-x   1 BPXROOT  TIVUSR     49152 Sep  1 16:04 JENKINS.ZDAT.RETIRE.LOAD/EBUD01
--rw-r--r--   1 BPXROOT  TIVUSR        38 Sep  1 16:04 buildReportOrder.txt
--rw-------   1 BPXROOT  TIVUSR      1015 Sep  1 16:04 packageBuildOutputs.properties
-
-** Build finished
-
+** Packaging completed successfully.
 ```
 </details>
 
@@ -350,14 +388,12 @@ Overview of the various ways to specify the structure within the repository:
 The password for the artifact repository can also represent the APIKey. It is recommended to store that inside the secret store of your pipeline orchestrator.
 
 ```
-groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy \
-        --workDir /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025 \
-        -p \
-        -aprop appArtifactRepository.properties \
-        -au http://10.3.20.231:8081/artifactory \
-        -ar example-repo-local \
-        -aU admin \
-        -aP xxxxxxxxxxx
+groovyz /var/pipeline/dbb/Pipeline/PackageBuildOutputs.groovy \
+        --workDir /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator \
+		-p --artifactRepositoryUrl http://10.3.20.231:8081/artifactory \
+		--artifactRepositoryUser admin \
+		--artifactRepositoryPassword xxxxxxxx \
+		--artifactRepositoryName RetirementCalculator
 ```
 
 <details>
@@ -366,43 +402,46 @@ groovyz /var/jenkins/pipeline/PackageBuildOutputs.groovy \
 PackageBuildOutputs console output
 
 ```
-
-PackageBuildOutputs.groovy --workDir /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025 -p -aprop appArtifactRepository.properties -au http://10.3.20.96:28081/repository -ar testMD -aU admin -aP nexusadmin
-** PackageBuildOutputs start at 20221207.050641.006
+** PackageBuildOutputs start at 20241028.151247.498
 ** Properties at startup:
    addExtension -> false
-   artifactRepository.directory ->
    artifactRepository.password -> xxxxxx
-   artifactRepository.repo -> testMD
-   artifactRepository.url -> http://10.3.20.96:28081/repository
+   artifactRepository.repo -> RetirementCalculator
+   artifactRepository.url -> http://10.3.20.231:8081/artifactory
    artifactRepository.user -> admin
-   buildReportOrder -> [/var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/BuildReport.json]
-   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT"]
-   packagingPropertiesFile -> /u/ibmuser/groovy/PublishingScript/packageBuildOutputs.properties
+   buildReportOrder -> [/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json]
+   copyModeMap -> ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" :
+"BINARY"]
+   fileEncoding -> UTF-8
+   generateSBOM -> false
+   generateWaziDeployAppManifest -> false
+   packagingPropertiesFile -> /u/mdalbin/dbb-MD/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
    publish -> true
-   startTime -> 20221207.050641.006
+   startTime -> 20241028.151247.498
    verbose -> false
-   workDir -> /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025
-** Read build report data from /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/BuildReport.json
-** Removing Output Records without deployType or with deployType=ZUNIT-TESTCASE
-** Files detected in /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/BuildReport.json
-   GITLAB.PROG.EPSM.LOAD(EPSMLIS), LOAD
-   GITLAB.PROG.EPSM.LOAD(EPSMPMT), LOAD
-   GITLAB.PROG.EPSM.LOAD(EPSMLIST), LOAD
-*** Number of build outputs to package: 3
-** Copying BuildOutputs to temporary package dir.
-     Copying GITLAB.PROG.EPSM.LOAD(EPSMLIS) to /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/tempPackageDir/GITLAB.PROG.EPSM.LOAD/EPSMLIS with DBB Copymode LOAD
-     Copying GITLAB.PROG.EPSM.LOAD(EPSMPMT) to /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/tempPackageDir/GITLAB.PROG.EPSM.LOAD/EPSMPMT with DBB Copymode LOAD
-     Copying GITLAB.PROG.EPSM.LOAD(EPSMLIST) to /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/tempPackageDir/GITLAB.PROG.EPSM.LOAD/EPSMLIST with DBB Copymode LOAD
-** Copying /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/BuildReport.json to temporary package dir as BuildReport.json.
-** Copying /u/ibmuser/groovy/PublishingScript/packageBuildOutputs.properties to temporary package dir.
-** Creating tar file at /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/build.20221206.032531.025.tar.
-** Package successfully created at /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/build.20221206.032531.025.tar.
-** Uploading package to Artifact Repository http://10.3.20.96:28081/repository/testMD/build.20221206.032531.025/build.20221206.032531.025.tar.
-** ArtifactRepositoryHelper started for upload of /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/build.20221206.032531.025.tar to http://10.3.20.96:28081/repository/testMD/build.20221206.032531.025/build.20221206.032531.025.tar
-** Uploading /var/jenkins/workspace/App-EPSM/outputs/build.20221206.032531.025/build.20221206.032531.025.tar to http://10.3.20.96:28081/repository/testMD/build.20221206.032531.025/build.20221206.032531.025.tar
-** Upload completed
-** Build finished
+   workDir -> /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator
+** Read build report data from '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json'.
+** Remove output records without deployType or with deployType=ZUNIT-TESTCASE
+** Deployable artifacts detected in '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/BuildReport.json':
+        'EBUD03' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD02' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD0RUN' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+        'EBUD01' from 'DBEHM.MIG.LOAD' with Deploy Type 'LOAD'
+*** Number of build outputs to package: 4
+** Copy build outputs to temporary package directory '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir'
+        Copy 'DBEHM.MIG.LOAD(EBUD03)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD03' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD02)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD02' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD0RUN)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD0RUN' with DBB Copymode 'LOAD'
+        Copy 'DBEHM.MIG.LOAD(EBUD01)' to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/bin/LOAD/EBUD01' with DBB Copymode 'LOAD'
+** Generate package build report order file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/buildReportOrder.txt'
+** Copy packaging properties config file to '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/tempPackageDir/packageBuildOutputs.properties'
+** Create tar file at /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar
+** Package '/u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar' successfully created.
+** Upload package to Artifact Repository 'http://10.3.20.231:8081/artifactory/RetirementCalculator/build.20241018.143823.127/build.20241018.143823.127.tar'.
+** ArtifactRepositoryHelper started for upload of /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar to http://10.3.20.231:8081/artifactory/RetirementCalculator/build.20241018.143823.127/build.20241018.143823.127.tar
+** Uploading /u/mdalbin/Migration-Modeler-MDLB-work/logs/RetirementCalculator/build.20241018.143823.127.tar to http://10.3.20.231:8081/artifactory/RetirementCalculator/build.20241018.143823.127/build.20241018.143823.127.tar...
+** Upload completed.
+** Packaging completed successfully.
 ```
 </details>
 
@@ -420,9 +459,11 @@ Parameter | Description
 ---------- | ----------------------------------------------------------------------------------------
 `copyModeMap` | configures the mapping of last level qualifier and the necessary copymode from PDS to USS.
 `deployTypesFilter` | to limit the scope of DBB deployTypes that are added to the package
+`includeLogs` | List of file patterns from the workDir, that should be addded to the package, such as build logs
 `addExtension` | Boolean flag to append the DBB deployType as the file extension to provide information about the deployment 
 `generateWaziDeployAppManifest` |  Boolean flag to indicate if the Wazi Deploy Application Manifest file should be created
-`includeLogs` | List of file patterns from the workDir, that should be addded to the package, such as build logs
+`generateSBOM` |  Boolean flag to indicate if a CycloneDX SBOM file should be created
+`publish` |  Boolean flag to indicate if the created TAR file should be uploaded to an Artifact Repository
 `fileEncoding` | File encoding for files generated as part of the process 
 
 Additionally, the ArtifactRepositoryHelpers accept a properties like [appArtifactRepository.properties](appArtifactRepository.properties) file to define:
@@ -441,77 +482,62 @@ Parameter | Description
 
 ```
   usage: PackageBuildOutputs.groovy [options]
- 
-  -w,--workDir <dir>                             Absolute path to the DBB build
-                                                 output directory
- 
-  -properties,--packagingPropertiesFile <file>   Absolute path of a property file
-                                                 containing application specific
-                                                 packaging details. 
-                                                                                                                                          
-  Optional:
-
-  -boFile,--buildReportOrderFile <file>          Name of the buildReportOrder file, used to specify
-                                                 buildReport.json files to be processed.
-
-  -bO,--buildReportOrder <buildReports>          Additional build reports to be processed. If -boFile and -bO 
-                                                 are used together, the build reports from -bO are 
-                                                 appended to the build reports from -boFile.
-
-  -t,--tarFileName <filename>                    Name of the package tar file.
-                                                 (Optional unless using --buildReportOrder or --buildReportOrderFile)
-
-  -d,--deployTypes <deployTypes>                 Comma-seperated list of deployTypes
-                                                 to filter on the scope of the tar
-                                                 file. (Optional)
-
-  -verb,--verbose                                Flag to provide more log output. (Optional)
-
-  -il,--includeLogs                              Comma-separated list of files/patterns
-                                                 from the USS build workspace
-
-  -ae,--addExtension                             Flag to add the deploy type extension to the member
-                                                 in the package tar file. (Optional)                                                                                              
-
-  -wd,--generateWaziDeployAppManifest            Flag indicating to generate and add the Wazi Deploy Application Manifest file
-  
-  -s,--sbom                                      Flag to control the generation of SBOM
-  
-  -sa,--sbomAuthor <sbomAuthor>                  Author of the SBOM, in form "Name <email>"
-
-  -h,--help                                      Prints this message
-
-  Optional Artifact Repsository upload opts:
- 
-  -p,--publish
-                     Flag to indicate package upload to
-                     the provided Artifactory server.
-                     (Optional)
- 
-  -v,--versionName <versionName>                 
-                     Name of the Artifactory version. (Optional)
-
-  -ad,--artifactRepositoryDirectory <repoDirectory>
-                     Directory path in the repository to store the build . (Optional)
- 
-  -aprop,--artifactRepositoryPropertyFile <propertyFile>
-                     Path of a property file containing application specific artifact
-                     repository details. (Optional)
-
-  -ar,--artifactRepositoryName <repoName>
-                     Artifact repository name to store the build. (Optional)
- 
-  -au,--artifactRepositoryUrl <url>
-                     URL to the Artifact repository server. (Optional)
-
-  -aU,--artifactRepositoryUser <user>
-                     User to connect to the Artifact repository server. (Optional)
-  
-  -aP,--artifactRepositoryPassword <password>
-                     Password to connect to the Artifact repository server. (Optional)
-  
-  -ah,--artifactRepositoryHttpClientProtocolVersion <protocolVersion>
-                     HttpClient.Version setting to override the HTTP protocol version. (Optional)
+ usage: PackageBuildOutputs.groovy [options]
+ -a,--application <application>
+      The name of the application
+ -ad,--artifactRepositoryDirectory <repoDirectory>
+      Directory path in the repository to store the build . (Optional)
+ -ae,--addExtension
+      Flag to add the deploy type extension to the member in the package tar file. (Optional)
+ -af,--applicationFolderPath <applicationFolderPath>
+      Path to the Application's Git repository folder
+ -ah,--artifactRepositoryHttpClientProtocolVersion
+ <httpClientProtocolVersion>
+      HttpClient.Version setting to override the HTTP protocol version. (Optional)
+ -aP,--artifactRepositoryPassword <password>
+      Password to connect to the Artifact repository server. (Optional)
+ -aprop,--artifactRepositoryPropertyFile <propertyFile>
+      Path of a property file containing application specific artifact  repository details. (Optional) ** (Deprecated)
+ -ar,--artifactRepositoryName <repoName>
+      Artifact repository name to store the build. (Optional)
+ -au,--artifactRepositoryUrl <url>
+      URL to the Artifact repository server. (Optional)
+ -aU,--artifactRepositoryUser <user>
+      User to connect to the Artifact repository server. (Optional)
+ -b,--branch <branch>
+      The git branch processed by the pipeline
+ -bO,--buildReportOrder <buildReportOrder>
+      List of build reports in order of processing
+ -boFile,--buildReportOrderFile <buildReportOrderFile>
+      A file that lists build reports in order of processing
+ -bp,--baselinePackage <baselinePackageFilePath>
+      Path to a baseline Package. (Optional)
+ -d,--deployTypes <deployTypes>
+      Comma-seperated list of deployTypes to filter on the scope of the tar file. (Optional)
+ -h,--help
+      Prints this message
+ -il,--includeLogs <includeLogs>
+      Comma-separated list of files/patterns from the USS build workspace.  (Optional)
+ -o,--owner <owner>
+      Owner of the packaged artifacts
+ -p,--publish
+      Flag to indicate package upload to the provided Artifact Repository server. (Optional)
+ -properties,--packagingPropertiesFile <packagingPropertiesFile>
+      Path of a property file containing application specific packaging details.
+ -s,--sbom
+      Flag to control the generation of SBOM
+ -sa,--sbomAuthor <sbomAuthor>
+      Author of the SBOM, in form "Name <email>"
+ -t,--tarFileName <filename>
+      Name of the package tar file. (Optional unless using --buildReportOrder or --buildReportOrderFile)
+ -v,--versionName <versionName>
+      Name of the version/package on the Artifact repository server. (Optional)
+ -verb,--verbose
+      Flag to provide more log output. (Optional)
+ -w,--workDir <dir>
+      Absolute path to the DBB build output directory
+ -wd,--generateWaziDeployAppManifest
+      Flag indicating to generate and add the Wazi Deploy Application Manifest file.
 ```
 
 ## Command Line Options Summary - ArtifactRepositoryHelpers
@@ -568,6 +594,24 @@ As an example, you can invoke the SBOM generation with the following command:
 
 By default, the SBOM file is generated in the `tempPackageDir` and named `sbom.json`.
 This way, it is automatically packaged in the TAR file that is created by the script, ensuring the package and its content are not tampered and correctly documented. 
+
+## Baseline Packages
+
+The CLI option `baselinePackage` can be used to specify a path to an existing package on z/OS Unix System Services. This package will then be used as a baseline, on which new artifacts documented in the provided build report(s) will be copied, potentially replacing the content of the baseline package.
+
+During the packaging process, the baseline package is expanded, and reorganization of the content is performed if necessary, to comply with the recommended internal layout. The artifacts are splited in two subfolders in the archive:
+- the `bin` subfolder contains artifacts that are meant to be deployed and constitute the core of the application version.
+- the `include` subfolder contains artifacts that represent interfaces of the application, that other applications can consume or reference (typically, public/shared Include Files like COBOL copybooks, and object decks that are statically linked by "consuming" loadmodules).
+
+Depending on the `fullPackage` flag, the behavior can be different:
+- when this flag is not specified, part of the content of the baseline package is deleted. Only the `include` subfolder is kept, and the `bin` subfolder is removed. The resulting package contains:
+  - the deployable artifacts documented by the provided build report(s) in the `bin` subfolder
+  - the existing interfaces from the baseline package, which can be overriden by public/shared Include Files and newly created object decks.
+- when this flag is specified, the content of the baseline package is preserved. The resulting package contains:
+  - the existing deployable artifacts from the baseline package in `bin`, which can be overridden by the new artifacts documented in the provided build report(s),
+  - the existing interfaces from the baseline package, which can be overridden by public/shared Include Files and newly created object decks.
+
+To determine which artifacts should be provided in the `include` subfolder, 
 
 
 ## Useful reference material

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -623,8 +623,12 @@ If an Application Descriptor file is found, the required information is leverage
 - the public or shared includes files present in the application's Git repository.
 
 These artifacts are placed in the `include` subfolder of the archive, within specific subfolders to segregate artifacts based on their nature:
-- the `include/bin` subfolder contains the object decks that other programs can statically link.
-- the `include/src` subfolder contains the public and shared include files, that other programs can reference.
+- the `lib` subfolder contains artifacts that are private to the application:
+     - the `lib/bin` subfolder contains object decks that the application is statically linking for its internal usage.
+     - the `lib/src` subfolder contains the include files that were classified as private to the application.
+- the `include/src` subfolder contains the public artifacts that other programs can reference:
+     - the `include/bin` subfolder contains the object decks that other programs can statically link.
+     - the `include/src` subfolder contains the public and shared include files, that other programs can reference.
 
 When used in conjunction with [baseline packages](#baseline-packages), it is possible to have an archive that contains all the interfaces of an application, combining previous versions of object decks (when they have not changed) with the newest material that was just built or changed in the application's Git repository.
 

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -14,6 +14,49 @@ copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LO
 #
 # deployTypesFilter=
 
+# Comma-separated list of deployTypes that describe >public interfaces<
+# that consuming applications pull into their build workspace as a build
+# dependency.
+#
+# Along with the the usage definition 'service interface' in the
+# 'Application Descriptor', these outputs will be made
+# available in a dedicated sub folder of the tar file, that
+# applications that need these modules as a build dependency
+# can include into their build scope/workspace.
+#
+# These deployTypes are excluded from being added to the /bin folder
+# that contains the deployable outputs.
+#
+# This is specifically useful for applications that provide object modules
+# of statically called submodules to other applications.
+# It does not effect modules that are called dynamically.
+publicInterfacesDeployTypes=OBJ
+
+# Comma-separated list of deployTypes that describe derived build outputs
+# that represent >private interfaces< that are required internally for by
+# the application
+#
+# Along with the required usage definition in the
+# 'Application Descriptor', these files will be made available
+# in a dedicated sub folder of the tar file, that
+# can then be included as a baseline package.
+#
+# These deployTypes are excluded from being added to the /bin folder
+# that contains the deployable outputs.
+#
+# This is useful for applications with static calls to provide object modules
+# of statically called submodules or generated source code such as
+# generated copybooks for BMS or DCLgen files for subsequent builds.
+privateInterfacesDeployTypes=OBJ,BMSCOPY
+
+# Publish source code interfaces that are declared as 'shared/public' in the
+# 'Application Descriptor' into dedicated subfolder for consumption by
+# applications that depend this application.
+# The packaging process retrieves the files directly from the
+# checked out Git repository.
+publishInterfaces=true
+
+
 # Comma-separated list of files/patterns from the USS build workspace. (Optional)
 #  Please note that the cli option `includeLogs` overwrites this setting
 #  Sample: includeLogs = *.log,*.xml

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -23,7 +23,7 @@ copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LO
 # Boolean setting to define if file the deployType should be added as the file extension
 #  Please note that the cli option `addExtension` can override this setting and activate it.
 #  Default: false
-addExtension=false
+addExtension=true
 
 # Boolean setting to define if the Wazi Deploy Application Manifest file should be generated
 #  Please note that the cli option `generateWaziDeployAppManifest` can override this setting and activate it.

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -18,7 +18,7 @@ copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LO
 # that consuming applications pull into their build workspace as a build
 # dependency.
 #
-# Along with the the usage definition 'service interface' in the
+# Along with the the usage definition 'service submodule' in the
 # 'Application Descriptor', these outputs will be made
 # available in a dedicated sub folder of the tar file, that
 # applications that need these modules as a build dependency

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -5,7 +5,7 @@
 # required mapping of last level dataset qualifier to DBB CopyToFS CopyMode
 #  DBB supported copy modes are documented at
 #  https://www.ibm.com/docs/api/v1/content/SS6T76_1.1.0/javadoc/com/ibm/dbb/build/DBBConstants.CopyMode.html
-copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY"]
+copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LOAD", "JCL": "TEXT", "EQALANGX" : "BINARY", "OBJ" : "BINARY"]
 
 # Comma-separated list of deployTypes to limit the scope of the tar
 # file to a subset of the build outputs. (Optional)
@@ -18,7 +18,7 @@ copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LO
 #  Please note that the cli option `includeLogs` overwrites this setting
 #  Sample: includeLogs = *.log,*.xml
 #
-# includeLogs = 
+# includeLogs =
 
 # Boolean setting to define if file the deployType should be added as the file extension
 #  Please note that the cli option `addExtension` can override this setting and activate it.

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -38,7 +38,7 @@ publicInterfacesDeployTypes=OBJ
 #
 # Along with the required usage definition in the
 # 'Application Descriptor', these files will be made available
-# in a dedicated sub folder of the tar file, that
+# in a dedicated sub folder 'lib' of the tar file, that
 # can then be included as a baseline package.
 #
 # These deployTypes are excluded from being added to the /bin folder

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -54,7 +54,7 @@ privateInterfacesDeployTypes=OBJ,BMSCOPY
 # applications that depend this application.
 # The packaging process retrieves the files directly from the
 # checked out Git repository.
-publishInterfaces=true
+publishInterfaces=false
 
 
 # Comma-separated list of files/patterns from the USS build workspace. (Optional)

--- a/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
@@ -1,5 +1,6 @@
 import groovy.transform.*
 import groovy.yaml.YamlBuilder
+import groovy.yaml.YamlSlurper
 import com.ibm.dbb.build.report.records.*
 
 /*
@@ -35,10 +36,35 @@ def initWaziDeployManifestGenerator(Properties props) {
 	wdManifest.metadata.annotations.creationTimestamp = props.startTime
 }
 
+def readWaziDeployManifestFile(File yamlFile, Properties props) {
+
+	def yamlSlurper = new YamlSlurper()
+	wdManifest = yamlSlurper.parse(yamlFile)
+	
+	// Metadata
+	wdManifest.metadata = new Metadata()
+
+	if (props.application) {
+		wdManifest.metadata.description = props.application
+		wdManifest.metadata.name = props.application
+	} else {
+		wdManifest.metadata.description = "UNDEFINED"
+		wdManifest.metadata.name = "UNDEFINED"
+	}
+
+	// Metadata information
+	wdManifest.metadata.version = (props.versionName) ? props.versionName : props.startTime
+	if (props.application) wdManifest.metadata.name = props.application
+
+	// Annotations
+	wdManifest.metadata.annotations = new Annotations()
+	wdManifest.metadata.annotations.creationTimestamp = props.startTime
+}
+
 /**
  * Append Artifact Record to Wazi Deploy Application Manifest 
  */
-def appendArtifactToAppManifest(DeployableArtifact deployableArtifact, String path, Record record, PropertiesRecord propertiesRecord){
+def appendArtifactToManifest(DeployableArtifact deployableArtifact, String path, Record record, DependencySetRecord dependencySetRecord, PropertiesRecord propertiesRecord) {
 
 	Artifact artifact = new Artifact()
 	artifact.name = deployableArtifact.file
@@ -62,21 +88,65 @@ def appendArtifactToAppManifest(DeployableArtifact deployableArtifact, String pa
 		}
 	}
 	// add type
-	artifact.type =deployableArtifact.deployType
+	artifact.type = deployableArtifact.deployType
 
 	// add hash
 	def gitHashInfo = retrieveBuildResultProperty (propertiesRecord, "githash")
 	artifact.hash =  (gitHashInfo) ? gitHashInfo : "UNDEFINED"
 
 	// adding artifact into applicationManifest
-	if (!wdManifest.artifacts) wdManifest.artifacts = new ArrayList<Artifact>()
+	if (!wdManifest.artifacts) {
+		wdManifest.artifacts = new ArrayList<Artifact>()
+	} else {
+		// Search for existing artifact with the same name and deployType
+		// Build another ArrayList with artifacts to be removed
+		ArrayList<Artifact> artifactsToBeRemoved = new ArrayList<Artifact>()
+		 
+		wdManifest.artifacts.each { searchedArtifact ->
+			if (searchedArtifact.name.equals(artifact.name) && searchedArtifact.type.equals(artifact.type)) {
+				artifactsToBeRemoved.add(searchedArtifact)
+			} 
+		}
+		if (!artifactsToBeRemoved.isEmpty()) {
+			wdManifest.artifacts.removeAll(artifactsToBeRemoved)
+		}
+	}
+	
 	wdManifest.artifacts.add(artifact)
 }
 
 /**
+ * Update Artifact Record to Wazi Deploy Application Manifest 
+ */
+def updateArtifactPathToManifest(String artifactName, String artifactType, String newPath) {
+	def searchedArtifacts = wdManifest.artifacts.findAll() { artifact ->
+		artifact.name.equals(artifactName) && artifact.type.equals(artifactType)
+	}
+	
+	if (searchedArtifacts) {
+		if (searchedArtifacts.size() == 1) {
+			def pathProperty = searchedArtifacts.first().properties.find() { property ->
+				property.key.equals("path")
+			}
+			if (pathProperty) {
+				pathProperty.value = newPath
+			}
+			return 0
+		} else if (searchedArtifacts.size() > 1) {
+			println("*! [ERROR] Can't update path for '${artifactName}.${artifactType}'. Multiple entries in Wazi Deploy Manifest file.")
+			return 1
+		}
+	} else {
+		println("*! [ERROR] Can't update path for '${artifactName}.${artifactType}'. No matching entry in Wazi Deploy Manifest file.")
+		return 1
+	}
+}
+
+
+/**
  * Append Artifact Deletion Record to Wazi Deploy Application Manifest 
  */
-def appendArtifactDeletionToAppManifest(DeployableArtifact deployableArtifact, String path, Record record, PropertiesRecord propertiesRecord){
+def appendArtifactDeletionToManifest(DeployableArtifact deployableArtifact, String path, Record record, PropertiesRecord propertiesRecord) {
 
 	Artifact deleted_artifact = new Artifact()
 	deleted_artifact.name = deployableArtifact.file
@@ -168,8 +238,7 @@ def writeApplicationManifest(File yamlFile, String fileEncoding, String verbose)
 }
 
 private def retrieveBuildResultProperty(PropertiesRecord buildResultPropertiesRecord, String propertyName) {
-
-	if (buildResultPropertiesRecord!=null) {
+	if (buildResultPropertiesRecord != null) {
 		def buildResultProperties = buildResultPropertiesRecord.getProperties()
 
 		def property = buildResultProperties.find {
@@ -178,8 +247,7 @@ private def retrieveBuildResultProperty(PropertiesRecord buildResultPropertiesRe
 
 		if (property) {
 			return property.getValue()
-		} else
-		{
+		} else {
 			return null
 		}
 	}

--- a/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
@@ -142,6 +142,28 @@ def updateArtifactPathToManifest(String artifactName, String artifactType, Strin
 	}
 }
 
+/**
+ * Remove Artifact Record to Wazi Deploy Application Manifest 
+ */
+def removeArtifactFromManifest(String artifactName, String artifactType) {
+	def searchedArtifacts = wdManifest.artifacts.findAll() { artifact ->
+		artifact.name.equals(artifactName) && artifact.type.equals(artifactType)
+	}
+	
+	if (searchedArtifacts) {
+		if (searchedArtifacts.size() == 1) {
+			wdManifest.artifacts.remove(searchedArtifacts[0])
+			return 0
+		} else if (searchedArtifacts.size() > 1) {
+			println("*! [ERROR] Can't remove artifact '${artifactName}.${artifactType}'. Multiple entries in Wazi Deploy Manifest file.")
+			return 1
+		}
+	} else {
+		println("*! [ERROR] Can't remove artifact '${artifactName}.${artifactType}'. No matching entry in Wazi Deploy Manifest file.")
+		return 1
+	}
+}
+
 
 /**
  * Append Artifact Deletion Record to Wazi Deploy Application Manifest 

--- a/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
@@ -1,0 +1,355 @@
+@groovy.transform.BaseScript com.ibm.dbb.groovy.ScriptLoader baseScript
+import com.ibm.dbb.metadata.*
+import com.ibm.dbb.dependency.*
+import com.ibm.dbb.build.*
+import groovy.transform.*
+import com.ibm.dbb.build.report.*
+import com.ibm.dbb.build.report.records.*
+import groovy.yaml.YamlSlurper
+import groovy.yaml.YamlBuilder
+import groovy.lang.GroovyShell
+import groovy.util.*
+import java.nio.file.*
+
+/**
+ * Utilities to read, update or export existing ApplicationDescriptor from/to YAML 
+ */
+
+class ApplicationDescriptor {
+    String application
+    String description
+    String owner
+    ArrayList<Source> sources
+    ArrayList<Baseline> baselines
+    ArrayList<DependencyDescriptor> dependencies
+    ArrayList<String> consumers
+}
+
+class Source {
+    String name
+    String repositoryPath
+    String language
+    String languageProcessor
+    String fileExtension
+    String artifactsType
+    ArrayList<FileDef> files
+}
+
+class FileDef {
+    String name
+    String type
+    String usage
+}
+
+class Baseline {
+    String branch
+    String baseline
+}
+
+class DependencyDescriptor {
+    String name
+    String version
+    String type
+}
+
+/**
+ * 
+ * Reads an existing application descriptor YAML
+ * returns an ApplicationDescriptor Object
+ * 
+ */
+def readApplicationDescriptor(File yamlFile) {
+    // Internal objects
+    def yamlSlurper = new groovy.yaml.YamlSlurper()
+    ApplicationDescriptor applicationDescriptor = yamlSlurper.parse(yamlFile)
+    return applicationDescriptor
+}
+
+/**
+ * Write an ApplicationDescriptor Object into a YAML file
+ */
+def writeApplicationDescriptor(File yamlFile, ApplicationDescriptor applicationDescriptor) {
+    // Sort source groups and files by name before writing to YAML file
+    if (applicationDescriptor.sources) {
+        applicationDescriptor.sources.sort {
+            it.name
+        }
+        applicationDescriptor.sources.each() { source ->
+            source.files.sort {
+                it.name
+            }
+        }
+    }
+
+    def yamlBuilder = new YamlBuilder()
+    // build updated application descriptor
+
+    yamlBuilder {
+        application applicationDescriptor.application
+        description applicationDescriptor.description
+        owner applicationDescriptor.owner
+        sources (applicationDescriptor.sources)
+        baselines (applicationDescriptor.baselines)
+        if (applicationDescriptor.dependencies) {
+            dependencies applicationDescriptor.dependencies
+        }
+        if (applicationDescriptor.consumers) {
+            consumers applicationDescriptor.consumers
+        }
+    }
+
+    // write file
+    yamlFile.withWriter("IBM-1047") { writer ->
+        writer.write(yamlBuilder.toString())
+    }
+	Process process = "chtag -tc IBM-1047 ${yamlFile.getAbsolutePath()}".execute()
+	process.waitFor()   
+}
+
+/**
+ * Method to update the Application Descriptor
+ * 
+ * Appends to an existing source sourceGroupName, if it exists.
+ * If the sourceGroupName cannot be found, it creates a new sourceGroup
+ * 
+ */
+
+def appendFileDefinition(ApplicationDescriptor applicationDescriptor, String sourceGroupName,
+							String language, String languageProcessor, String artifactsType,
+							String fileExtension, String repositoryPath, String name,
+							String type, String usage) {
+
+    def sourceGroupRecord
+
+    def fileRecord = new FileDef()
+    fileRecord.name = name
+    fileRecord.type = type
+    fileRecord.usage = usage
+    
+    if (!applicationDescriptor.sources) {
+       applicationDescriptor.sources = new ArrayList<Source>()
+    }
+
+    existingSourceGroup = applicationDescriptor.sources.find(){ source ->
+        source.name == sourceGroupName
+    }
+
+    if (existingSourceGroup) { // append file record definition to existing sourceGroup
+        sourceGroupRecord = existingSourceGroup
+        
+        // check if the fileRecord already exists, and this is an update
+
+        existingFileRecord = sourceGroupRecord.files.find(){ file ->
+            file.name == fileRecord.name
+        }
+
+        if (existingFileRecord) { // update existing file record
+            existingFileRecord.type = type
+            existingFileRecord.usage = usage
+		} else { // add a new record
+            sourceGroupRecord.files.add(fileRecord)
+        }
+	} else {
+        // create a new source group entry
+        sourceGroupRecord = new Source()
+        sourceGroupRecord.name = sourceGroupName
+        sourceGroupRecord.language = language
+        sourceGroupRecord.languageProcessor = languageProcessor
+        sourceGroupRecord.fileExtension = fileExtension
+        sourceGroupRecord.artifactsType = artifactsType
+        sourceGroupRecord.repositoryPath = repositoryPath
+
+        sourceGroupRecord.files = new ArrayList<FileDef>()
+        // append file record
+        sourceGroupRecord.files.add(fileRecord)
+        applicationDescriptor.sources.add(sourceGroupRecord)
+    }
+}
+
+
+/**
+ * Method to remove a file from the Application Descriptor
+ */
+
+def removeFileDefinition(ApplicationDescriptor applicationDescriptor, String sourceGroupName, String name) {
+
+    if (applicationDescriptor.sources) {
+        def existingSourceGroup = applicationDescriptor.sources.find() { source ->
+            source.name == sourceGroupName
+        }
+        if (existingSourceGroup) { // Found an existing Source Group that matches
+            def existingFileDef = existingSourceGroup.files.find { file ->
+                file.name.equals(name)
+            }
+            if (existingFileDef) {
+//                println "Found matching file ${existingFileDef.name}"
+                existingSourceGroup.files.remove(existingFileDef)
+            }
+        }
+    }
+}
+
+/**
+ * Method to add an application dependency 
+ */
+
+def addApplicationDependency(ApplicationDescriptor applicationDescriptor, String applicationDependency, String version, String type) {
+    if (!applicationDescriptor.dependencies) {
+        applicationDescriptor.dependencies = new ArrayList<DependencyDescriptor>()
+    }
+    def existingDependencies = applicationDescriptor.dependencies.findAll() {
+        it.name.equals(applicationDependency) & it.type.equals(type)
+    }
+    if (!existingDependencies) {
+        def dependency = new DependencyDescriptor()
+        dependency.name = applicationDependency
+        dependency.version = version
+        dependency.type = type
+        applicationDescriptor.dependencies.add(dependency)
+        applicationDescriptor.dependencies.sort {
+            it.name
+        } 
+    }
+}
+
+/**
+ * Method to add a consumer to list of consumers
+ */
+
+def addApplicationConsumer(ApplicationDescriptor applicationDescriptor, String consumingApplication) {
+    
+    if (!applicationDescriptor.consumers) {
+        applicationDescriptor.consumers = new ArrayList<String>()
+    }
+    // don't add the "owning" application
+    if (applicationDescriptor.application != consumingApplication) {
+        def existingConsumers = applicationDescriptor.consumers.findAll() {
+            it.equals(consumingApplication)
+        }
+        if (!existingConsumers) {     
+            applicationDescriptor.consumers.add(consumingApplication)
+            applicationDescriptor.consumers.sort()
+        }
+    } 
+}
+
+/**
+ * Method to drop the source entries
+ */
+
+def resetAllSourceGroups(ApplicationDescriptor applicationDescriptor) {
+    applicationDescriptor.sources = new ArrayList<Source>()
+}
+
+/**
+ * Method to drop the source entries
+ */
+
+def resetConsumersAndDependencies(ApplicationDescriptor applicationDescriptor) {
+    applicationDescriptor.consumers = new ArrayList<Source>()
+    applicationDescriptor.dependencies = new ArrayList<Source>()
+}
+
+/**
+ * Method to create an empty application descriptor object 
+ */
+def createEmptyApplicationDescriptor() {
+    ApplicationDescriptor applicationDescriptor = new ApplicationDescriptor()
+    applicationDescriptor.sources = new ArrayList<Source>()
+    applicationDescriptor.baselines = new ArrayList<Baseline>()
+    return applicationDescriptor
+}
+
+/**
+ * Method to return a FileDef that matches what we are looking for
+ * Return null if nothing is found
+ * Return null if multiple entries are found (for source groups or files) with a warning message
+ */
+
+def getFileUsage(ApplicationDescriptor applicationDescriptor, String sourceGroup, String name) {
+	if (applicationDescriptor) {
+		def matchingSourceGroups = applicationDescriptor.sources.findAll() { matchingSourceGroup ->
+			matchingSourceGroup.name.equals(sourceGroup)
+		}
+		if (matchingSourceGroups) {
+			if (matchingSourceGroups.size() == 1) {
+				def matchingFiles = matchingSourceGroups[0].files.findAll() { matchingFile ->
+					matchingFile.name.equalsIgnoreCase(name)
+				}
+				if (matchingFiles) {
+					if (matchingFiles.size() == 1) {
+						return matchingFiles[0].usage
+					} else {
+						println("*! [WARNING] Multiple Files found matching '${name}'. Skipping search.")
+						return null
+					}
+				} else {
+					return null
+				}
+			} else {
+				println("*! [WARNING] Multiple Source Groups found matching '${sourceGroup}'. Skipping search.")
+				return null
+			}
+		} else {
+			return null
+		}
+	} else {
+		return null
+	}
+}
+
+/**
+ * Method to return an ArraList that contains relative Paths
+ * to public & shared include files
+ */
+
+def getFilesByTypeAndUsage(ApplicationDescriptor applicationDescriptor, String artifactsType, String usage) {
+	if (applicationDescriptor) {
+		def matchingSourceGroups = applicationDescriptor.sources.findAll() { matchingSourceGroup ->
+			matchingSourceGroup.artifactsType.equals(artifactsType)
+		}
+		ArrayList<String> files = new ArrayList<String>()
+
+		if (matchingSourceGroups) {
+			matchingSourceGroups.each() { matchingSourceGroup ->
+				def matchingFiles = matchingSourceGroup.files.findAll() { matchingFile ->
+					matchingFile.usage.equals(usage)
+				}
+				if (matchingFiles) {
+					matchingFiles.each() { matchingFile ->
+						files.add("${matchingSourceGroup.repositoryPath}/${matchingFile.name}.${matchingSourceGroup.fileExtension}")
+					}
+				}
+			}
+		}
+		if (!files.isEmpty()) {
+			return files
+		}
+	}
+}
+
+/**
+ * Method to add a baseline 
+ * If an existing baseline for a given branch already exists, the method replaces it
+ */
+
+def addBaseline(ApplicationDescriptor applicationDescriptor, String branch, String baseline) {
+	if (applicationDescriptor.baselines) {
+		def existingBaselines = applicationDescriptor.baselines.findAll() { baselineDefinition ->
+			baselineDefinition.branch.equals(branch)
+		}
+		existingBaselines.forEach() { existingBaseline ->
+			applicationDescriptor.baselines.remove(existingBaseline)
+	    }
+	} else {
+		applicationDescriptor.baselines = new ArrayList<Baseline>()
+	}
+
+	if (applicationDescriptor.baselines) {
+		applicationDescriptor.sources = new ArrayList<Source>()
+	}
+	Baseline newBaseline = new Baseline()
+	newBaseline.branch = branch
+	newBaseline.baseline = baseline
+	applicationDescriptor.baselines.add(newBaseline)
+}

--- a/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
@@ -299,6 +299,40 @@ def getFileUsage(ApplicationDescriptor applicationDescriptor, String sourceGroup
 }
 
 /**
+ * Method to return a FileDef that matches what we are looking for
+ * Return null if nothing is found
+ * Return null if multiple entries are found (for artifactsType or files) with a warning message
+ */
+
+def getFileUsageByType(ApplicationDescriptor applicationDescriptor, String artifactsType, String name) {
+	if (applicationDescriptor) {
+		def matchingSourceGroups = applicationDescriptor.sources.findAll() { matchingSourceGroup ->
+			matchingSourceGroup.artifactsType.equals(artifactsType)
+		}
+		if (matchingSourceGroups) {
+			def allMatchingFiles = new ArrayList<FileDef>()
+			matchingSourceGroups.each { matchingSourceGroup ->
+				def matchingFiles = matchingSourceGroup.files.findAll() { matchingFile ->
+					matchingFile.name.equalsIgnoreCase(name)
+				}
+				allMatchingFiles.addAll(matchingFiles)
+			}
+			if (allMatchingFiles.size() == 1) {
+				return allMatchingFiles[0].usage
+			} else {
+				println("*! [WARNING] Multiple Files found matching '${name}'. Skipping search.")
+				return null
+			}
+		} else {
+			return null
+		}
+	} else {
+		return null
+	}
+}
+
+
+/**
  * Method to return an ArraList that contains relative Paths
  * to public & shared include files
  */

--- a/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
@@ -279,10 +279,13 @@ def getFileUsage(ApplicationDescriptor applicationDescriptor, String sourceGroup
 				if (matchingFiles) {
 					if (matchingFiles.size() == 1) {
 						return matchingFiles[0].usage
-					} else {
-						println("*! [WARNING] Multiple Files found matching '${name}'. Skipping search.")
+					} else if (matchingFiles.size() > 1) {
+						println("*! [WARNING] Multiple files found matching '${name}'. Skipping search.")
 						return null
-					}
+					} else {
+						println("*! [WARNING] No file found matching '${name}'. Skipping search.")
+						return null
+          }
 				} else {
 					return null
 				}
@@ -319,10 +322,13 @@ def getFileUsageByType(ApplicationDescriptor applicationDescriptor, String artif
 			}
 			if (allMatchingFiles.size() == 1) {
 				return allMatchingFiles[0].usage
-			} else {
-				println("*! [WARNING] Multiple Files found matching '${name}'. Skipping search.")
+			} else if (allMatchingFiles.size() > 1) {
+			  println("*! [WARNING] Multiple files found matching '${name}'. Skipping search.")
 				return null
-			}
+			} else {
+			  println("*! [WARNING] No file found matching '${name}'. Skipping search.")
+				return null
+      }
 		} else {
 			return null
 		}


### PR DESCRIPTION
This PR adds support for Application Descriptor files and baseline packages.

Application Descriptor files are YAML files in the application's Git repository that describes the content of the application. If the path to the application's folder checked out on USS is provided through the `--applicationFolderPath` parameter, the Application Descriptor file `applicationDescriptor.yml` is looked up is parsed to get the list of include files that are public, that can be consumed by other applications.

If the path to a baseline package is provided through the `baselinePackage` parameter, the baseline package is expanded in the temporary folder, before its content can be overridden by artifacts that are documented in the Build Report provided as input.

The structure of the archive is significantly changing:
- in the `bin` subfolder the artifacts were just built as documented in the provided DBB Build Report
- in the `include` subfolder,
  - in the `bin` subfolder, the object decks that can be used/included by other applications for static linkage
  - in the `src` subfolder, the public and shared includes files, that other applications can reference
- in the `lib`subfolder, 
  - in the `bin` subfolder, the object decks that can be used internally for static linkage. Or other derived build output that is necessary for subsequent builds of the application itself.