### PR TITLE
Feature/concert SBOM integration

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -615,7 +615,7 @@ if (rc == 0) {
 			def processCmd = [
 				"sh",
 				"-c",
-				"tar rvf $tarFile concert_build_manifest.yaml"
+				"tar rUXf $tarFile concert_build_manifest.yaml"
 			]
 	
 			def processRC = runProcess(processCmd, tempLoadDir)

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -888,6 +888,10 @@ def parseInput(String[] cliArgs){
 			println("*! [ERROR] Missing publish parameter ('--publish'). It is required for generating the Concert Build Manifest file.")
 			rc = 2
 		}
+		if (props.bO || props.boFile) {
+			println("*! [ERROR] conflicting parameter ('-bO or -boFile'). IBM Concert Build Manifest file is creating with single builds only.")
+			rc = 2
+		}
 	}
 
 	return props

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -609,6 +609,22 @@ if (rc == 0) {
 				concertManifestGeneratorUtilities.addSBOMInfoToBuild(concertBuild, sbomFileName, sbomSerialNumber)
 			}			
 			concertManifestGeneratorUtilities.writeBuildManifest(new File("$tempLoadDir/concert_build_manifest.yaml"), props.fileEncoding, props.verbose)
+			println("** Add concert build config yaml to tar file at ${tarFile}")
+			// Note: https://www.ibm.com/docs/en/zos/2.4.0?topic=scd-tar-manipulate-tar-archive-files-copy-back-up-file
+			// To save all attributes to be restored on z/OS and non-z/OS systems : tar -UX
+			def processCmd = [
+				"sh",
+				"-c",
+				"tar rvf $tarFile concert_build_manifest.yaml"
+			]
+	
+			def processRC = runProcess(processCmd, tempLoadDir)
+			rc = Math.max(rc, processRC)
+			if (rc == 0) {
+				println("** Package '${tarFile}' successfully appended with concert manifest yaml.")
+			} else {
+				println("*! [ERROR] Error appending '${tarFile}' with concert manifest yaml rc=$rc.")
+			}
 		}
 	}
 }

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -63,8 +63,8 @@ import com.ibm.jzos.ZFile;
 @Field Properties props = null
 def scriptDir = new File(getClass().protectionDomain.codeSource.location.path).parent
 @Field def wdManifestGeneratorUtilities = loadScript(new File("${scriptDir}/utilities/WaziDeployManifestGenerator.groovy"))
-@Field def concertManifestGeneratorUtilities = loadScript(new File("${scriptDir}/utilities/concertBuildManifestGenerator.groovy"))
 @Field def sbomUtilities
+@Field def concertManifestGeneratorUtilities
 @Field def rc = 0
 @Field def sbomSerialNumber
 @Field def sbomFileName
@@ -376,9 +376,10 @@ if (rc == 0) {
 		// Initialize Concert Build Manifest Generator
 		if (props.generateConcertBuildManifest && props.generateConcertBuildManifest.toBoolean()) {
 			// Concert Build Manifest			
+			
+			concertManifestGeneratorUtilities = loadScript(new File("${scriptDir}/utilities/concertBuildManifestGenerator.groovy"))
 			concertManifestGeneratorUtilities.initConcertBuildManifestGenerator()
 			concertBuild = concertManifestGeneratorUtilities.addBuild(props.application, props.versionName, buildNumber)
-
 			concertManifestGeneratorUtilities.addRepositoryToBuild(concertBuild, scmInfo.uri, scmInfo.branch, scmInfo.shortCommit)
 		}
 		def String tarFileName = (props.tarFileName) ? props.tarFileName  : "${tarFileLabel}.tar"
@@ -602,12 +603,12 @@ if (rc == 0) {
 		}
 			
 		if (concertManifestGeneratorUtilities && props.generateConcertBuildManifest && props.generateConcertBuildManifest.toBoolean() && rc == 0) {
-			// concert_build_manifest.yml is the default name of the manifest file
+			// concert_build_manifest.yaml is the default name of the manifest file
 						
 			if (props.generateSBOM && props.generateSBOM.toBoolean() && rc == 0) {
 				concertManifestGeneratorUtilities.addSBOMInfoToBuild(concertBuild, sbomFileName, sbomSerialNumber)
 			}			
-			concertManifestGeneratorUtilities.writeBuildManifest(new File("$tempLoadDir/concert_build_manifest.yml"), props.fileEncoding, props.verbose)
+			concertManifestGeneratorUtilities.writeBuildManifest(new File("$tempLoadDir/concert_build_manifest.yaml"), props.fileEncoding, props.verbose)
 		}
 	}
 }

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -888,8 +888,8 @@ def parseInput(String[] cliArgs){
 			println("*! [ERROR] Missing publish parameter ('--publish'). It is required for generating the Concert Build Manifest file.")
 			rc = 2
 		}
-		if (props.bO || props.boFile) {
-			println("*! [ERROR] conflicting parameter ('-bO or -boFile'). IBM Concert Build Manifest file is creating with single builds only.")
+		if (opts.bO || opts.boFile) {
+			println("*! [ERROR] conflicting parameter ('-bO or -boFile'). IBM Concert Build Manifest file is created with single builds only.")
 			rc = 2
 		}
 	}

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -576,7 +576,7 @@ This way, it is automatically packaged in the TAR file that is created by the sc
 
 This `PackageBuildOutputs.groovy` script is able to generate an IBM Concert Build manifest based on the information contained in the DBB Build Report and the published package information. The output is a YAML file that adheres to IBM Concert Build specification YAML format. The generation of the CycloneDX SBOM is a pre-requisite as the IBM Concert Build manifest will reference the CycloneDX SBOM file for detailed information about the build outputs.
 
-To enable the generation of the IBM Concert manifest/config file, the `-ic/--generateConcertBuildManifest` flag must be passed.
+To enable the generation of the IBM Concert Build manifest, the `-ic/--generateConcertBuildManifest` flag must be passed.
 
 As an example, you can invoke IBM Concert generation with the following command:
 

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -46,6 +46,9 @@ This section provides a more detailed explanation of how the PackageBuildOutputs
 6. **(Optional) Publish to Artifact Repository such as JFrog Artifactory or Sonartype Nexus**
     1. Publishes the TAR file to the artifact repository based on the given configuration using the ArtifactRepositoryHelpers script. Consider a Nexus RAW, or a Artifactory Generic as the repository type. **Please note**: The ArtifactRepositoryHelpers script is updated for DBB 2.0 and requires to run on JAVA 11. The publishing can be configured to pass in the artifact repository information as well as the path within the repository `directory/[versionName|buildLabel]/tarFileName` via the cli.
 
+7. **(Optional) Generate IBM Concert Build manifest**
+   1. Based on the collected build outputs information, the IBM Concert Build Manifest file is generated and saved as concert_build_manifest.yaml. This is a feeder file to publish build information into IBM Concert. It will only be generated if both sbom and packaging options are in effect. 
+
 Notes: 
 * The script doesn't manage the deletions of artifacts. Although they are reported in the DBB Build Reports, deletions are not handled by this script.
 
@@ -566,8 +569,22 @@ As an example, you can invoke the SBOM generation with the following command:
 /usr/lpp/dbb/v2r0/bin/groovyz -cp /u/mdalbin/SBOM/cyclonedx-core-java-8.0.3.jar:/u/mdalbin/SBOM/jackson-annotations-2.16.1.jar:/u/mdalbin/SBOM/jackson-core-2.16.1.jar:/u/mdalbin/SBOM/jackson-databind-2.16.1.jar:/u/mdalbin/SBOM/jackson-dataformat-xml-2.16.1.jar:/u/mdalbin/SBOM/json-schema-validator-1.2.0.jar:/u/mdalbin/SBOM/packageurl-java-1.5.0.jar /u/mdalbin/SBOM/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputsWithSBOM.groovy --workDir /u/ado/workspace/MortgageApplication/feature/consumeRetirementCalculatorServiceImpacts/build-20240312.1/logs --tarFileName MortgageApplication.tar --addExtension -s -sa "David Gilmour <david.gilmour@pinkfloyd.com>"
 ~~~~ 
 
-By default, the SBOM file is generated in the `tempPackageDir` and named `sbom.json`.
+By default, the SBOM file is generated in the `tempPackageDir` and named `<buildnumber>_sbom.json`.
 This way, it is automatically packaged in the TAR file that is created by the script, ensuring the package and its content are not tampered and correctly documented. 
+
+## IBM Concert Build (SBOM) manifest generation
+
+This `PackageBuildOutputs.groovy` script is able to generate an IBM Concert SBOM file based on the information contained in the DBB Build Report and the published package information. The output is a yaml file that adheres to IBM Concert build configuration yaml format. The generation of the CycloneDX SBOM is a pre-requisite as the IBM Concert file will redirect to CycloneDX for detailed information about the build outputs. 
+
+To enable the generation of the IBM Concert manifest/config file, the `-ic/--generateConcertBuildManifest` flag must be passed.
+
+As an example, you can invoke IBM Concert generation with the following command:
+
+~~~~
+/usr/lpp/dbb/v2r0/bin/groovyz -cp /u/mdalbin/SBOM/cyclonedx-core-java-8.0.3.jar:/u/mdalbin/SBOM/jackson-annotations-2.16.1.jar:/u/mdalbin/SBOM/jackson-core-2.16.1.jar:/u/mdalbin/SBOM/jackson-databind-2.16.1.jar:/u/mdalbin/SBOM/jackson-dataformat-xml-2.16.1.jar:/u/mdalbin/SBOM/json-schema-validator-1.2.0.jar:/u/mdalbin/SBOM/packageurl-java-1.5.0.jar /u/mdalbin/SBOM/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputsWithSBOM.groovy --workDir /u/ado/workspace/MortgageApplication/feature/consumeRetirementCalculatorServiceImpacts/build-20240312.1/logs --tarFileName MortgageApplication.tar --addExtension -s -sa "David Gilmour <david.gilmour@pinkfloyd.com>" -ic
+~~~~ 
+
+By default, the concert build manifest file is generated in the `tempPackageDir` and named `concert_build_manifest.yaml`. 
 
 
 ## Useful reference material

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -572,7 +572,7 @@ As an example, you can invoke the SBOM generation with the following command:
 By default, the SBOM file is generated in the `tempPackageDir` and named `<buildnumber>_sbom.json`.
 This way, it is automatically packaged in the TAR file that is created by the script, ensuring the package and its content are not tampered and correctly documented. 
 
-## IBM Concert Build (SBOM) manifest generation
+## IBM Concert Build manifest generation
 
 This `PackageBuildOutputs.groovy` script is able to generate an IBM Concert SBOM file based on the information contained in the DBB Build Report and the published package information. The output is a yaml file that adheres to IBM Concert build configuration yaml format. The generation of the CycloneDX SBOM is a pre-requisite as the IBM Concert file will redirect to CycloneDX for detailed information about the build outputs. 
 

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -574,7 +574,7 @@ This way, it is automatically packaged in the TAR file that is created by the sc
 
 ## IBM Concert Build manifest generation
 
-This `PackageBuildOutputs.groovy` script is able to generate an IBM Concert SBOM file based on the information contained in the DBB Build Report and the published package information. The output is a yaml file that adheres to IBM Concert build configuration yaml format. The generation of the CycloneDX SBOM is a pre-requisite as the IBM Concert file will redirect to CycloneDX for detailed information about the build outputs. 
+This `PackageBuildOutputs.groovy` script is able to generate an IBM Concert Build manifest based on the information contained in the DBB Build Report and the published package information. The output is a YAML file that adheres to IBM Concert Build specification YAML format. The generation of the CycloneDX SBOM is a pre-requisite as the IBM Concert Build manifest will reference the CycloneDX SBOM file for detailed information about the build outputs.
 
 To enable the generation of the IBM Concert manifest/config file, the `-ic/--generateConcertBuildManifest` flag must be passed.
 

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -584,7 +584,7 @@ As an example, you can invoke IBM Concert generation with the following command:
 /usr/lpp/dbb/v2r0/bin/groovyz -cp /u/mdalbin/SBOM/cyclonedx-core-java-8.0.3.jar:/u/mdalbin/SBOM/jackson-annotations-2.16.1.jar:/u/mdalbin/SBOM/jackson-core-2.16.1.jar:/u/mdalbin/SBOM/jackson-databind-2.16.1.jar:/u/mdalbin/SBOM/jackson-dataformat-xml-2.16.1.jar:/u/mdalbin/SBOM/json-schema-validator-1.2.0.jar:/u/mdalbin/SBOM/packageurl-java-1.5.0.jar /u/mdalbin/SBOM/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputsWithSBOM.groovy --workDir /u/ado/workspace/MortgageApplication/feature/consumeRetirementCalculatorServiceImpacts/build-20240312.1/logs --tarFileName MortgageApplication.tar --addExtension -s -sa "David Gilmour <david.gilmour@pinkfloyd.com>" -ic
 ~~~~ 
 
-By default, the concert build manifest file is generated in the `tempPackageDir` and named `concert_build_manifest.yaml`. 
+By default, the IBM Concert Build manifest file is generated in the `tempPackageDir` and named `concert_build_manifest.yaml`. 
 
 
 ## Useful reference material

--- a/Pipeline/PackageBuildOutputs/README.md
+++ b/Pipeline/PackageBuildOutputs/README.md
@@ -578,7 +578,7 @@ This `PackageBuildOutputs.groovy` script is able to generate an IBM Concert Buil
 
 To enable the generation of the IBM Concert Build manifest, the `-ic/--generateConcertBuildManifest` flag must be passed.
 
-As an example, you can invoke IBM Concert generation with the following command:
+As an example, you can invoke the generation of an IBM Concert Build manifest with the following command:
 
 ~~~~
 /usr/lpp/dbb/v2r0/bin/groovyz -cp /u/mdalbin/SBOM/cyclonedx-core-java-8.0.3.jar:/u/mdalbin/SBOM/jackson-annotations-2.16.1.jar:/u/mdalbin/SBOM/jackson-core-2.16.1.jar:/u/mdalbin/SBOM/jackson-databind-2.16.1.jar:/u/mdalbin/SBOM/jackson-dataformat-xml-2.16.1.jar:/u/mdalbin/SBOM/json-schema-validator-1.2.0.jar:/u/mdalbin/SBOM/packageurl-java-1.5.0.jar /u/mdalbin/SBOM/dbb/Pipeline/PackageBuildOutputs/PackageBuildOutputsWithSBOM.groovy --workDir /u/ado/workspace/MortgageApplication/feature/consumeRetirementCalculatorServiceImpacts/build-20240312.1/logs --tarFileName MortgageApplication.tar --addExtension -s -sa "David Gilmour <david.gilmour@pinkfloyd.com>" -ic

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -30,6 +30,11 @@ addExtension=false
 #  Default: false
 generateWaziDeployAppManifest=false
 
+# Boolean setting to define if the Wazi Deploy Application Manifest file should be generated
+#  Please note that the cli option `generateWaziDeployAppManifest` can override this setting and activate it.
+#  Default: false
+generateConcertBuildManifest=false
+
 # Boolean setting to define if SBOM based on cycloneDX should be generated
 #  Please note that the cli option `generateSBOM` can override this setting and activate it.
 #  Requires the classpath to contain the cycloneDX libs

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -30,8 +30,8 @@ addExtension=false
 #  Default: false
 generateWaziDeployAppManifest=false
 
-# Boolean setting to define if the Wazi Deploy Application Manifest file should be generated
-#  Please note that the cli option `generateWaziDeployAppManifest` can override this setting and activate it.
+# Boolean setting to define if the IBM Concert Build Manifest file should be generated
+#  Please note that the cli option `generateConcertBuildManifest` can override this setting and activate it.
 #  Default: false
 generateConcertBuildManifest=false
 

--- a/Pipeline/PackageBuildOutputs/utilities/concertBuildManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/concertBuildManifestGenerator.groovy
@@ -1,0 +1,128 @@
+import groovy.transform.*
+import groovy.yaml.YamlBuilder
+import com.ibm.dbb.build.report.records.*
+
+/*
+ * This is a utility method to generate the Wazi Deploy Application Manifest file  
+ * See https://www.ibm.com/docs/en/developer-for-zos/16.0?topic=files-application-manifest-file
+ */
+
+/**
+ * Initialize application manifest file
+ * Should be the constructor
+ */
+
+@Field ConcertBuildManifest concertManifest = new ConcertBuildManifest()
+
+def initConcertBuildManifestGenerator(Properties props, String buildNumber) {
+	// Metadata
+	concertManifest.concert = new Concertdata()
+	concertManifest.concert.builds = new Builds()
+	concertManifest.concert.builds[0].repositories = new Repositories()
+	concertManifest.concert.builds[0].library = new Library()
+
+	if (props.application) {
+		concertManifest.concert.builds[0].component_name = props.application
+	} else {
+		concertManifest.concert.builds[0].component_name = "UNDEFINED"
+	} 
+	concertManifest.concert.builds[0].number = buildNumber
+	concertManifest.concert.builds[0].output_file = concertManifest.concert.builds[0].component_name + "_sbom.json"
+
+	// Metadata information
+	concertManifest.concert.builds[0].version = (props.versionName) ? props.versionName : props.startTime
+
+}
+
+def setScmInfo(HashMap<String, String> scmInfoMap) {
+	concertManifest.concert.builds[0].repositories[0].name = concertManifest.concert.builds[0].component_name
+	concertManifest.concert.builds[0].repositories[0].url = scmInfoMap.uri
+	concertManifest.concert.builds[0].repositories[0].branch = scmInfoMap.branch
+	concertManifest.concert.builds[0].repositories[0].commit_sha = scmInfoMap.shortCommit
+}
+
+def setPackageInfo(HashMap<String, String> packageInfoMap) {
+	concertManifest.concert.builds[0].library.scope = 'tar'
+	concertManifest.concert.builds[0].library.name = concertManifest.concert.builds[0].component_name
+	concertManifest.concert.builds[0].library.filename = packageInfoMap.name
+	concertManifest.concert.builds[0].library.version = concertManifest.concert.builds[0].version
+	concertManifest.concert.builds[0].library.url = packageInfoMap.uri
+}
+
+def setSBOMInfo(String sbomFileName, String sbomSerialNumber) {
+	concertManifest.concert.builds[0].library.cyclonedx_bom_link  = new SBOMInfo()
+	concertManifest.concert.builds[0].library.cyclonedx_bom_link.file = sbomFileName
+	concertManifest.concert.builds[0].library.cyclonedx_bom_link.data = new SBOMdata()
+	concertManifest.concert.builds[0].library.cyclonedx_bom_link.data.serial_number = sbomSerialNumber
+	concertManifest.concert.builds[0].library.cyclonedx_bom_link.data.version = 1
+}
+
+/**
+ * Write an Concert Build Manifest  a YAML file
+ */
+def writeBuildManifest(File yamlFile, String fileEncoding, String verbose){
+	println("** Generate Concert Build  Manifest file to $yamlFile")
+	def yamlBuilder = new YamlBuilder()
+    
+	yamlBuilder {
+			specVersion concertManifest.specVersion
+			concert concertManifest.concert
+		}
+
+	if (verbose && verbose.toBoolean()) {
+		println yamlBuilder.toString()
+	}
+
+	// write file
+	yamlFile.withWriter(fileEncoding) { writer ->
+		writer.write(yamlBuilder.toString())
+	}
+}
+
+/**
+ * Concert Deploy  Manifest Classes and Helpers
+ */
+
+class ConcertBuildManifest {
+    String specVersion = "1.0.2"
+    Concertdata concert
+}
+
+class Concertdata {
+    Builds[] builds
+}
+
+class Builds {
+    String component_name
+    String output_file
+    String number 
+    String version
+    Library library
+    Repositories[] repositories
+}
+
+class Repositories {
+    String name
+    String url
+    String branch
+    String commit_sha
+}
+
+class Library {
+    String scope
+	String name
+    String version
+	String filename
+    String url
+    SBOMInfo cyclonedx_bom_link
+}
+
+class SBOMInfo {
+    String file
+	SBOMdata data
+}
+
+class SBOMdata {
+    String serial_number
+	String version
+}

--- a/Pipeline/PackageBuildOutputs/utilities/concertBuildManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/concertBuildManifestGenerator.groovy
@@ -79,7 +79,7 @@ def writeBuildManifest(File yamlFile, String fileEncoding, String verbose){
  */
 
 class ConcertBuildManifest {
-    String specVersion = "1.0.2"
+    String specVersion = "1.0.3"
     Concertdata concert
 }
 

--- a/Pipeline/PackageBuildOutputs/utilities/sbomGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/sbomGenerator.groovy
@@ -50,15 +50,15 @@ def initializeSBOM(String sbomAuthor, String serialNumber) {
 			author.setEmail(sbomAuthorFields[1].replaceAll(">", "").trim())
 			sbomMetadata.addAuthor(author)
 		} else {
-			println("*! Warning: SBOM Author not correctly formed, expecting 'Name <email>' format. Skipping.")
+			println("*! [WARNING] SBOM Author not correctly formed, expecting 'Name <email>' format. Skipping.")
 		}
 	} else {
-		println("*! Warning: empty SBOM Author. It is recommend to specify a valid Author.")	
+		println("*! [WARNING] empty SBOM Author. It is recommend to specify a valid Author.")	
 	}  
 	if (serialNumber) {
 		sbom.setSerialNumber(serialNumber)	 
 	} else {
-		println("*! Warning: Serial Number has been regenerated.")	
+		println("*! [WARNING] Serial Number has been regenerated.")	
 		sbom.setSerialNumber("url:uuid:" + UUID.randomUUID().toString())
 	}
 	 

--- a/Pipeline/PackageBuildOutputs/utilities/sbomGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/sbomGenerator.groovy
@@ -19,6 +19,9 @@ import org.cyclonedx.model.*
  *
  * Version 1 - 04/2024
  *  Initial implementation of SBOM Generation
+ * Version 2  - 10/2024
+ *  Changed to pass SerialNumber from the packaging script. Changed type "container"
+ *  to "library"
  ************************************************************************************/
 
 
@@ -30,10 +33,8 @@ import org.cyclonedx.model.*
 @Field ArrayList<Dependency> sbomDependencies
 @Field Bom sbom
 
-def initializeSBOM(String sbomAuthor) {
+def initializeSBOM(String sbomAuthor, String serialNumber) {
 	sbom = new Bom();
-	sbom.setSerialNumber("url:uuid:" + UUID.randomUUID().toString());
-	sbom.setVersion(1);
 	LifecycleChoice sbomLifecycleChoice = new LifecycleChoice()
 	sbomLifecycleChoice.setPhase(LifecycleChoice.Phase.POST_BUILD)
 	Lifecycles sbomLifecycles = new Lifecycles()
@@ -54,6 +55,14 @@ def initializeSBOM(String sbomAuthor) {
 	} else {
 		println("*! Warning: empty SBOM Author. It is recommend to specify a valid Author.")	
 	}  
+	if (serialNumber) {
+		sbom.setSerialNumber(serialNumber)	 
+	} else {
+		println("*! Warning: Serial Number has been regenerated.")	
+		sbom.setSerialNumber("url:uuid:" + UUID.randomUUID().toString())
+	}
+	 
+	sbom.setVersion(1) 
 	sbom.setMetadata(sbomMetadata)
     sbom.setDependencies(new ArrayList<Dependency>())
 }
@@ -95,7 +104,7 @@ def addEntryToSBOM(DeployableArtifact deployableArtifact, HashMap<String, Object
 	// Set the properties of the Deployable Artifact
 	ArrayList<Property> deployableArtifactComponentProperties = new ArrayList<Property>()
 	Property deployableArtifactContainerComponentProperty = new Property()
-	deployableArtifactContainerComponentProperty.setName("container")
+	deployableArtifactContainerComponentProperty.setName("library")
 	deployableArtifactContainerComponentProperty.setValue(container)
 	deployableArtifactComponentProperties.add(deployableArtifactContainerComponentProperty)
 	Property deployableArtifactDeployTypeComponentProperty = new Property()


### PR DESCRIPTION
This pull request is to implement a feature integrating z/OS builds with [IBM Concert](https://www.ibm.com/products/concert) This includes changes within the packaging script to create concert specific SBOM manifest or configurations. IBM Concert requires zOS Application builds to generate build config in the format https://github.ibm.com/roja/sample_app_data/blob/main/102/system-z/build-config-sample.yaml so that it can be supplied to concert dashboards. This enables zOS application changes to be visible in Concert dashboards along with the rest of the enterprise applications. 