### PR TITLE
Fix Common Backend script to correctly support preview build scenario

### DIFF
--- a/Templates/Common-Backend-Scripts/dbbBuild.sh
+++ b/Templates/Common-Backend-Scripts/dbbBuild.sh
@@ -159,6 +159,7 @@ AppDir=""        # Derived Application Directory
 HLQ=""           # Derived High Level Qualifier
 HLQPrefix=""     # Prefix of HLQ, either specified via the cli option -q or via configuration file
 Type=""          # Derived Build Type
+userDefinedBuildType="" #  Flag if the user has provided the Build Type as argument
 baselineRef=""   # baselineReference that is computed by utilities/dbbBuildUtils.sh
 propOverrides="" # Override of default build parameters for zAppBuild
 #  computed by utilities/dbbBuildUtils.sh
@@ -262,6 +263,7 @@ if [ $rc -eq 0 ]; then
           break
         fi
         Type="$argument"
+        userDefinedBuildType=1
         ;;
       p)
         argument="$OPTARG"

--- a/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
+++ b/Templates/Common-Backend-Scripts/utilities/dbbBuildUtils.sh
@@ -69,7 +69,7 @@ computeBuildConfiguration() {
                 HLQ="${HLQ}.${mainBranchSegmentTrimmed:0:1}${segmentName:0:7}"
             fi
 
-                        if [ -z "${Type}" ]; then
+            if [ -z "${Type}" ]; then
                 Type="--impactBuild"
 # obtain the baselineRef from file
                 getBaselineReference
@@ -209,7 +209,7 @@ computeBuildConfiguration() {
 
         # append pipeline preview if specified
         if [ "${PipelineType}" == "preview" ]; then
-            if [ -z "${Type}" ]; then
+            if [ -z "${userDefinedBuildType}" ]; then
                 Type="${Type} --preview"
             fi
         fi


### PR DESCRIPTION
This addresses broken preview mode #303 .

In case the CBS compute the build type, the preview option will be appended to the build build configuration.
In case the has overridden the build type via the cli argument `-t`, the preview mode will not be considered.

This is aligned to the implementation of the zBuilder.sh wrapper