### PR TITLE
Handle delete-only case in dbbBuild.sh

### DIFF
--- a/Templates/Common-Backend-Scripts/dbbBuild.sh
+++ b/Templates/Common-Backend-Scripts/dbbBuild.sh
@@ -128,7 +128,7 @@ Help() {
 # Build Type Customization
 # Configuration file leveraged by the backend scripts
 # Either an absolute path or a relative path to the current working directory
-SCRIPT_HOME="`dirname "$0"`"
+SCRIPT_HOME="/u/gitlab/dbb/Templates/Common-Backend-Scripts"
 pipelineConfiguration="${SCRIPT_HOME}/pipelineBackend.config"
 buildUtilities="${SCRIPT_HOME}/utilities/dbbBuildUtils.sh"
 # Customization - End
@@ -390,7 +390,7 @@ validateOptions() {
     fi
   fi
 
-  BuildGroovy="${zAppBuild}/build.groovy"
+  BuildGroovy="/var/dbb/dbb-zappbuild_300/build.groovy"
 
   if [ ! -f "${BuildGroovy}" ]; then
     rc=8
@@ -516,18 +516,22 @@ if [ $rc -eq 0 ]; then
 
       # For each list in logListArray, if found in the last Build Log Directory, get its size (character count), then
       # increase logListSize by that amount.
-      for list in ${logListArray}; do
+      for list in ${logListArray[@]}; do
+        echo "Print: "${list}
         if [ -f ${list} ]; then
+          echo "Found: "${list}
           # wc -c will return the two values; Character Count and Log File Path.  Parse out the Character Count.
           set $(wc -c <${list})
-          echo ?${list} size: ?$1
-          logListSize=${totalLogListSize}+$1
-          echo ?totalLogListSize: ?${totalLogListSize}
+          echo "${list} size: "$1
+          totalLogListSize=$((${totalLogListSize}+$1))
+          echo "totalLogListSize: "${totalLogListSize}
+        else
+          echo "Not found: "${list}
         fi
       done
 
       # Error/warning if both build and file list have 0 character count (i.e. are empty)       
-      if [ ${totalLogListSize} ] = 0; then
+      if [ ${totalLogListSize} = 0 ]; then
         rc=4
         ERRMSG=$PGM": [WARNING] DBB Build Error. No files on build list or deleted files list. rc="$rc
         echo $ERRMSG

--- a/Templates/Common-Backend-Scripts/dbbBuild.sh
+++ b/Templates/Common-Backend-Scripts/dbbBuild.sh
@@ -168,6 +168,11 @@ nestedApplicationFolder="" # Flag to understand a nested repository
 
 LastBuildLog=""
 buildlistsize=0
+# TODO: new
+totalLogListSize=0
+buildListFile=""
+deletedFilesListFile=""
+# TODO: end new
 
 DBBLogger=""
 zAppBuildVerbose=""
@@ -503,33 +508,34 @@ if [ $rc -eq 0 ]; then
 
     ## Except for the reset mode, check for "nothing to build" condition and throw an error to stop pipeline
     if [ "$Type" != "--reset" ]; then
+      
+      # Locate buildList and deletedFilesList in Build Log Directory within outDir, and group them in logListArray
+      buildListFile="${outDir}/buildList.txt"
+      deletedFilesListFile="${outDir}/deletedFilesList.txt"
+      logListArray=(${buildListFile} ${deletedFilesListFile})
 
-      # Locate the most recent Build Log Directory within outDir. The Build Log Directories are Time Stamped.
-      # Therefore, the last directory entry will be the most recent Build Log. The directory will always be
-      # be created by DBB, but "buildList.txt" may not.  If not created, array will will be blank.
-      array=$(find ${outDir} -name "buildList.txt")
-      for log in ${array[@]}; do
-        LastBuildLog=${log}
-        echo $PGM": [INFO] LastBuildLog = ${LastBuildLog}"
+      # For each list in logListArray, if found in the last Build Log Directory, get its size (character count), then
+      # increase logListSize by that amount.
+      for list in ${logListArray}; do
+        if [ -f ${list} ]; then
+          # wc -c will return the two values; Character Count and Log File Path.  Parse out the Character Count.
+          set $(wc -c <${list})
+          echo ?${list} size: ?$1
+          logListSize=${totalLogListSize}+$1
+          echo ?totalLogListSize: ?${totalLogListSize}
+        fi
       done
 
-      # If "buildList.txt" was found in the last Build Log Directory, determine the character count.
-      # wc -c will return the two values; Character Count and Log File Path.  Parse out the Character Count.
-      if [ -z ${LastBuildLog} ]; then
-        buildlistsize=0
-      else
-        set $(wc -c <${LastBuildLog})
-        buildlistsize=$1
-      fi
-
-      if [ $buildlistsize = 0 ]; then
+      # Error/warning if both build and file list have 0 character count (i.e. are empty)       
+      if [ ${totalLogListSize} ] = 0; then
         rc=4
-        ERRMSG=$PGM": [WARNING] DBB Build Error. No source changes detected. rc="$rc
+        ERRMSG=$PGM": [WARNING] DBB Build Error. No files on build list or deleted files list. rc="$rc
         echo $ERRMSG
       else
         ERRMSG=$PGM": [INFO] DBB Build Complete. rc="$rc
         echo $ERRMSG
       fi
+
     else
       ERRMSG=$PGM": [INFO] DBB Reset Complete. rc="$rc
       echo $ERRMSG

--- a/Templates/Common-Backend-Scripts/dbbBuild.sh
+++ b/Templates/Common-Backend-Scripts/dbbBuild.sh
@@ -128,7 +128,7 @@ Help() {
 # Build Type Customization
 # Configuration file leveraged by the backend scripts
 # Either an absolute path or a relative path to the current working directory
-SCRIPT_HOME="/u/gitlab/dbb/Templates/Common-Backend-Scripts"
+SCRIPT_HOME="`dirname "$0"`"
 pipelineConfiguration="${SCRIPT_HOME}/pipelineBackend.config"
 buildUtilities="${SCRIPT_HOME}/utilities/dbbBuildUtils.sh"
 # Customization - End
@@ -166,13 +166,10 @@ propOverrides="" # Override of default build parameters for zAppBuild
 outDir=""                  # Computed output directory to store build protocols
 nestedApplicationFolder="" # Flag to understand a nested repository
 
-LastBuildLog=""
-buildlistsize=0
-# TODO: new
+# Local variables for checking the contents of buildList and deletedFilesList
 totalLogListSize=0
 buildListFile=""
 deletedFilesListFile=""
-# TODO: end new
 
 DBBLogger=""
 zAppBuildVerbose=""
@@ -390,7 +387,7 @@ validateOptions() {
     fi
   fi
 
-  BuildGroovy="/var/dbb/dbb-zappbuild_300/build.groovy"
+  BuildGroovy="${zAppBuild}/build.groovy"
 
   if [ ! -f "${BuildGroovy}" ]; then
     rc=8
@@ -517,16 +514,10 @@ if [ $rc -eq 0 ]; then
       # For each list in logListArray, if found in the last Build Log Directory, get its size (character count), then
       # increase logListSize by that amount.
       for list in ${logListArray[@]}; do
-        echo "Print: "${list}
         if [ -f ${list} ]; then
-          echo "Found: "${list}
           # wc -c will return the two values; Character Count and Log File Path.  Parse out the Character Count.
           set $(wc -c <${list})
-          echo "${list} size: "$1
           totalLogListSize=$((${totalLogListSize}+$1))
-          echo "totalLogListSize: "${totalLogListSize}
-        else
-          echo "Not found: "${list}
         fi
       done
 

--- a/Templates/Common-Backend-Scripts/dbbBuild.sh
+++ b/Templates/Common-Backend-Scripts/dbbBuild.sh
@@ -524,13 +524,12 @@ if [ $rc -eq 0 ]; then
       # Error/warning if both build and file list have 0 character count (i.e. are empty)       
       if [ ${totalLogListSize} = 0 ]; then
         rc=4
-        ERRMSG=$PGM": [WARNING] DBB Build Error. No files on build list or deleted files list. rc="$rc
+        ERRMSG=$PGM": [WARNING] DBB Build Error. No source changes detected. rc="$rc
         echo $ERRMSG
       else
         ERRMSG=$PGM": [INFO] DBB Build Complete. rc="$rc
         echo $ERRMSG
       fi
-
     else
       ERRMSG=$PGM": [INFO] DBB Reset Complete. rc="$rc
       echo $ERRMSG


### PR DESCRIPTION
This PR for the Common Back-end Scripts Template's `dbbBuild.sh` file adds handling for the use case where the only source changes are file deletion (i.e. files are only listed in `deletedFilesList.txt` but not in `buildList.txt`).

With this PR, the pipeline can continue (e.g. with packaging) in this use case, instead of stopping with RC=4.

Resolves #305 