### PR TITLE
no retry on http status code 201

### DIFF
--- a/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
+++ b/Pipeline/PackageBuildOutputs/ArtifactRepositoryHelpers.groovy
@@ -30,11 +30,12 @@ import java.nio.file.Paths
  */
 
 @Field int MAX_RESEND = 10;
+@Field validStatusCodes = [200, 201] // 200=OK, 201=Created
 
 def <T> CompletableFuture<HttpResponse<T>>
 		tryResend(HttpClient client, HttpRequest request, BodyHandler<T> handler,
 				 int count, HttpResponse<T> resp) {
-	if (resp.statusCode() == 200 || count >= MAX_RESEND) {
+	if (validStatusCodes.contains(resp.statusCode()) || count >= MAX_RESEND) {
 		return CompletableFuture.completedFuture(resp);
 	} else {
 		return client.sendAsync(request, handler)
@@ -174,7 +175,7 @@ def evaluateHttpResponse (HttpResponse response, String action, boolean verbose)
     def statusCode = response.statusCode()
     if (verbose) println "*** HTTP-Status Code: $statusCode"
     def responseString = response.body()
-    if ((statusCode != 201) && (statusCode != 200)) {
+    if (!(validStatusCodes.contains(statusCode))) {
         rc = 1
         println("** Artifactory $action failed with statusCode : $statusCode")
         println("** Response: " + response);


### PR DESCRIPTION
The script ArtifactRepositoryHelpers.groovy has a built-in mechanism to retry failed communication attempts. That mechanism repeats a request up to ten times if that request fails. Whether or not a request has failed depends on its HTTP response code. The current version of the script only accepts a response code of 200 (OK) as successful. This leads to the unfortunate behavior that an upload will be repeated ten times when an artifact repository replies with the valid response code 201 (Created).

If repeated uploads of the same file are permitted by the artifact repository, the overall return code of the script becomes zero since the last HTTP response is delivered as finalResponse, no matter if successful or not. A response code of 201 is accepted as valid in the method evaluateHttpResponse but not in the retry logic in tryResend.

However, if the artifact repository does not allow repeated uploads of the same file — such as may be the case for release packages — the first upload will be successful and return status 201, but the subsequent uploads will fail with code 400 (Bad Request) or 403 (Forbidden). Since the last response is delivered as finalResponse, the overall return code of the script is 1 (failed).

With this commit, a change is made to the script to accept HTTP response code 201 as successful.