### PR TITLE
Update Schemas

### DIFF
--- a/Schema/LegacyVersions/buildConfigurationSchema-v1.0.0.json
+++ b/Schema/LegacyVersions/buildConfigurationSchema-v1.0.0.json
@@ -245,6 +245,7 @@
         "type": "object",
         "description": "Properties provided to the current context",
         "required": ["name"],
+        "additionalProperties": false,
         "properties": {
           "name": { "$ref": "#/$defs/variableName" },
           "value": { "$ref": "#/$defs/variableValue" },

--- a/Schema/LegacyVersions/buildConfigurationSchema-v1.0.1.json
+++ b/Schema/LegacyVersions/buildConfigurationSchema-v1.0.1.json
@@ -244,6 +244,7 @@
         "type": "object",
         "description": "Properties provided to the current context",
         "required": ["name"],
+        "additionalProperties": false,
         "properties": {
           "name": { "$ref": "#/$defs/variableName" },
           "value": { "$ref": "#/$defs/variableValue" },

--- a/Schema/applicationConfigurationSchema.json
+++ b/Schema/applicationConfigurationSchema.json
@@ -73,6 +73,7 @@
                   "type": "object",
                   "description": "Properties provided to the current context",
                   "required": ["name"],
+                  "additionalProperties": false,
                   "properties": {
                     "name": { "$ref": "#/$defs/variableName" },
                     "value": { "$ref": "#/$defs/variableValue" },

--- a/Schema/buildConfigurationSchema.json
+++ b/Schema/buildConfigurationSchema.json
@@ -244,6 +244,7 @@
         "type": "object",
         "description": "Properties provided to the current context",
         "required": ["name"],
+        "additionalProperties": false,
         "properties": {
           "name": { "$ref": "#/$defs/variableName" },
           "value": { "$ref": "#/$defs/variableValue" },


### PR DESCRIPTION
Configuration Variables now disallow additional property keys as they were always meant to.