### PR TITLE
Comment about CI_CLONE_PATH for the z/OS GitLab Runner template

### DIFF
--- a/Templates/GitlabCIPipeline-for-zos-native-runner/README.md
+++ b/Templates/GitlabCIPipeline-for-zos-native-runner/README.md
@@ -56,7 +56,7 @@ The following variables need to be defined and configured as the environment var
 Variable | Description | Value
 --- | --- | ---
 AutomationToken | [Group access token](https://docs.gitlab.com/ee/api/rest/#personalprojectgroup-access-tokens) to be used for authentication when invoke GitLab CLI REST interfaces. | No default value
-CI_CLONE_PATH | Even if not used in the cloning process, it defines the absolute location where artifacts are meant to be found during the artifact upload. | $CI_BUILDS_DIR/$CI_PROJECT_NAME/build-$CI_PIPELINE_ID
+GIT_CLONE_PATH | Even if not used in the cloning process, it defines the absolute location where artifacts are meant to be found during the artifact upload. | $CI_BUILDS_DIR/$CI_PROJECT_NAME/build-$CI_PIPELINE_ID
 
 The following variables need to be updated within the pipeline definition file: `.gitlab-ci.yaml`.
 


### PR DESCRIPTION
The z/OS Gitlab Runner template needs to have the CI_CLONE_PATH variable defined accordingly, as this variable is used by GitLab CI to locate artifacts that need to be uploaded to GitLab.
This variable needs to point to the location where the application's repository is cloned. This is currently missing in the documentation.