### PR TITLE
Skip setting mainBuildBranch config for epic, release or project branch

### DIFF
--- a/Templates/Common-Backend-Scripts/utilities/dbbzBuilderUtils.sh
+++ b/Templates/Common-Backend-Scripts/utilities/dbbzBuilderUtils.sh
@@ -76,7 +76,7 @@ computeBuildConfiguration() {
                 getBaselineReference
                 Lifecycle="${Lifecycle} --baselineRef ${baselineRef}"
                 # Release maintenance / epic / project branch clones the dependency information from the main build branch
-                writezBuilderOverride "${mainBranchSegment}"
+                
                 # appending the --debug flag to compile with TEST options
                 # Lifecycle="${Lifecycle} --debug"
             fi


### PR DESCRIPTION
This is addressing user feedback, that noticed, that a zBuilderConfigOverrides configuration file got produced even for the integration branch type `epic, release or project` .