### PR TITLE
Enable zBuilder.sh wrapper for zBuilder Package and Publish tasks

### DIFF
--- a/Templates/Common-Backend-Scripts/README.md
+++ b/Templates/Common-Backend-Scripts/README.md
@@ -300,8 +300,12 @@ CLI parameter | Description
 -b `<branch>` | **Git branch** that is built. Used to compute various build properties such as the `--hlq` and build type.
 -p `<build/release/preview>` | (Optional) **Pipeline Type** to indicate a `build` pipeline (build only with test/debug options) or a `release` pipeline (build for optimized load modules), or if it runs in `preview` mode.
 -v | (Optional) zBuilder verbose tracing flag.
--t `<buildTypeArgument>` | (Optional) **zBuilder Build lifecycle** to override the build type, such as `full`, or `impact`. Arguments must be provided between quotes - e.g.: `-t 'full'`. Providing this parameter overrides the computation of the build type in the backend scripts. For instance can be used to initialize the DBB Metadatastore. 
--q `<hlqPrefix>` |(Optional) **HLQ prefix**. Default is retrieved from the [pipelineBackend.config](pipelineBackend.config) file, if the configuration file is not modified - the default value is set to the user executing the script.
+-t `<buildTypeArgument>` | (Optional) **zBuilder Build lifecycle** to override the build type, such as `full`, or `impact`. Arguments must be provided between quotes - e.g.: `-t 'full'`. Providing this parameter overrides the computation of the build type in the backend scripts. For instance can be used to initialize the DBB Metadatastore.
+-q `<hlqPrefix>` | (Optional) **HLQ prefix**. Default is retrieved from the [pipelineBackend.config](pipelineBackend.config) file, if the configuration file is not modified - the default value is set to the user executing the script.
+-i `<buildIdentifier>` | (Optional) **Build identifier** passed to the zBuilder package and publish task as `--build-id`. See [build context inputs](https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-package#build-context-inputs).
+-r `<releaseIdentifier>` | (Optional) **Release identifier** passed to the zBuilder package and publish task as `--release-id`. See [build context inputs](https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-package#build-context-inputs).
+-u `<artifactRepositoryUser>` | (Optional) **Artifact repository user name** for the zBuilder publish task. Overrides the `zBuilderPublishArtifactRepositoryUser` value set in [pipelineBackend.config](pipelineBackend.config). Only applies to **password-based authentication** (see [Artifact repository authentication](#artifact-repository-authentication) below).
+-s `<artifactRepositoryPasswordFile>` | (Optional) **Artifact repository password file** path for the zBuilder publish task. Overrides the `zBuilderPublishArtitfRepositoryPassword` value set in [pipelineBackend.config](pipelineBackend.config). Only applies to **password-based authentication** (see [Artifact repository authentication](#artifact-repository-authentication) below).
 
 **Pipeline type**
 
@@ -309,6 +313,16 @@ The type of pipeline (`-p` option), is used to modify the operational behavior o
 * `build` configures the build options for test/debug options. This is the **default**.
 * `release` used to indicate to produce executables with the flag for performance-optimized runtime modules. This is required for the release pipelines which include release candidate packages.
 * `preview` configures the build process to execute without producing any outputs. It is used to preview what the build will do. The pipeline should not have any subsequent actions.
+
+**Artifact repository authentication**
+
+The zBuilder publish task supports two authentication modes as described in the [IBM documentation](https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-publish#cli-authentication-options):
+
+* **Password mode** — Supply a user name (`--arid`) and a path to a password file (`--arpf`). This mode is supported by `zBuilder.sh` through the `zBuilderPublishArtifactRepositoryUser` and `zBuilderPublishArtitfRepositoryPassword` settings in [pipelineBackend.config](pipelineBackend.config), which can be overridden at invocation time with the `-u` and `-s` CLI flags.
+
+* **Token mode** — Supply an API token file (`--artf`). **This mode is not yet supported** by `zBuilder.sh`. A future update will add a corresponding `-k <tokenFile>` CLI option and the matching `artifactRepositoryToken` configuration variable.
+
+> **Note:** Credentials should never be passed as plain-text values. Use a password file or token file stored in a secured location on the z/OS system and reference the file path only.
 
 #### Output
 

--- a/Templates/Common-Backend-Scripts/pipelineBackend.config
+++ b/Templates/Common-Backend-Scripts/pipelineBackend.config
@@ -34,6 +34,24 @@ logsDir="logs"
 ## End of Shared Configuration parameters    ########################################################
 #####################################################################################################
 
+#####################################################################################################
+## zBuilder.sh parameters  ##########################################################################
+#####################################################################################################
+
+# User to connect to the Artifact repository server for the Publish Task
+# https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-publish
+# e.q.:  zBuilderPublishArtifactRepositoryUser=admin
+zBuilderPublishArtifactRepositoryUser=""
+
+# Password file with obfuscated Artifact repository password
+# to connect to the Artifact repository server
+# https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-publish
+# e.q.: zBuilderPublishArtitfRepositoryPassword="/etc/dbb/zbuilder/artifactorypwd.txt"
+zBuilderPublishArtitfRepositoryPassword=""
+
+#####################################################################################################
+## End of zBuilder.sh parameters     ################################################################
+#####################################################################################################
 
 #####################################################################################################
 ## DBB-BUILD.sh parameters ##########################################################################
@@ -177,7 +195,7 @@ sbomAuthor=""
 cycloneDXlibraries=/var/dbb/additionalLibraries/cyclonedx-core-java-8.0.3.jar:/var/dbb/additionalLibraries/jackson-annotations-2.16.1.jar:/var/dbb/additionalLibraries/jackson-core-2.16.1.jar:/var/dbb/additionalLibraries/jackson-databind-2.16.1.jar:/var/dbb/additionalLibraries/jackson-dataformat-xml-2.16.1.jar:/var/dbb/additionalLibraries/json-schema-validator-1.2.0.jar:/var/dbb/additionalLibraries/packageurl-java-1.5.0.jar
 
 #####################################################################################################
-#### Artifact repository upload options    ##########################################################
+#### Artifact repository upload options using PackageBuildOutputs.groovy ############################
 #####################################################################################################
 #  the below section configures the Publishing
 #  to Artifact Repository such as JFrog Artifactory or Sonartype Nexus

--- a/Templates/Common-Backend-Scripts/zBuilder.sh
+++ b/Templates/Common-Backend-Scripts/zBuilder.sh
@@ -189,7 +189,7 @@ zBuilderPublishArtifactRepositoryUser=""     # Artifact repository user (CLI ove
 zBuilderPublishArtitfRepositoryPassword="" # Artifact repository password file (CLI override via -s)
 
 DBBLogger=""
-zAppBuildVerbose=""
+Verbose=""
 HELP=$1
 
 if [ "$HELP" = "?" ]; then
@@ -602,6 +602,10 @@ if [ $rc -eq 0 ]; then
     fi
     if [ ! -z "${releaseIdentifier}" ]; then
         CMD="${CMD} --release-id ${releaseIdentifier}"
+    fi
+
+    if [ ! -z "${Verbose}" ]; then
+        CMD="${CMD} --verbose"
     fi
 
     echo $PGM": [INFO] ${CMD}"

--- a/Templates/Common-Backend-Scripts/zBuilder.sh
+++ b/Templates/Common-Backend-Scripts/zBuilder.sh
@@ -45,6 +45,8 @@
 # Date       Who Vers  Description
 # ---------- --- ----- --------------------------------------------------------------
 # 2024/12/12 DB  1.0.0 Initial Release
+# 2025/04/07 DB  1.1.0 Ability to fetch external dependencies based on application descriptor
+# 2026/08/04 DB  1.2.0 zBuilder Package and Publish task integration
 #===================================================================================
 Help() {
     echo $PGM" - Invoke DBB zBuilder ("$PGMVERS")                       "
@@ -116,6 +118,20 @@ Help() {
     echo "                                                              "
     echo "                 Ex: -t 'full'                                "
     echo "                                                              "
+    echo "       -u <ArtiRepoUser>   - (Optional) Artifact repository   "
+    echo "                             user name to override the        "
+    echo "                             configured value in              "
+    echo "                             pipelineBackend.config           "
+    echo "                                                              "
+    echo "                 Ex: myUser                                   "
+    echo "                                                              "
+    echo "       -s <ArtiRepoPwdFile>- (Optional) Artifact repository   "
+    echo "                             password file path to override   "
+    echo "                             the configured value in          "
+    echo "                             pipelineBackend.config           "
+    echo "                                                              "
+    echo "                 Ex: /var/pipeline/secrets/artiRepo.password  "
+    echo "                                                              "
     echo "       -v                 - (Optional) Verbose tracing        "
     echo "                                                              "
     echo "                                                              "
@@ -138,7 +154,7 @@ fetchBuildDependenciesUtilities="${SCRIPT_HOME}/utilities/fetchBuildDependencies
 #export BASH_XTRACEFD=1  # Write set -x trace to file descriptor
 
 PGM=$(basename "$0")
-PGMVERS="1.10"
+PGMVERS="1.20"
 USER=$USER
 SYS=$(uname -Ia)
 
@@ -165,6 +181,12 @@ zBuilderConfigOverrides="" # Override of default build config for zBuilder
 zBuilderLogDir=""          # Path where zBuilder will store the logs
 buildListFile=""           # Location of the generate zBuilder buildList
 buildlistsize=0            # Used to assess if files got built
+
+buildIdentifier=""         # zBuilder package task build identifier (build context variable)
+releaseIdentifier=""       # zBuilder package task release identifier (build context variable)
+
+zBuilderPublishArtifactRepositoryUser=""     # Artifact repository user (CLI override via -u)
+zBuilderPublishArtitfRepositoryPassword="" # Artifact repository password file (CLI override via -s)
 
 DBBLogger=""
 zAppBuildVerbose=""
@@ -216,7 +238,7 @@ if [ $rc -eq 0 ]; then
     #
     # Get Options
     if [ $rc -eq 0 ]; then
-        while getopts "h:w:a:b:q:p:t:v" opt; do
+        while getopts "h:w:a:b:q:p:t:i:r:u:s:v" opt; do
             case $opt in
             h)
                 Help
@@ -266,6 +288,50 @@ if [ $rc -eq 0 ]; then
                 fi
                 Lifecycle="$argument"
                 userDefinedLifecycle=1 # set flag
+                ;;
+            i)
+                argument="$OPTARG"
+                nextchar="$(expr substr $argument 1 1)"
+                if [ -z "$argument" ] || [ "$nextchar" = "-" ]; then
+                    rc=4
+                    ERRMSG=$PGM": [WARNING] The build identifier is required. rc="$rc
+                    echo $ERRMSG
+                    break
+                fi
+                buildIdentifier="$argument"
+                ;;                
+            r)
+                argument="$OPTARG"
+                nextchar="$(expr substr $argument 1 1)"
+                if [ -z "$argument" ] || [ "$nextchar" = "-" ]; then
+                    rc=4
+                    ERRMSG=$PGM": [WARNING] The release identifier is required. rc="$rc
+                    echo $ERRMSG
+                    break
+                fi
+                releaseIdentifier="$argument"
+                ;;
+            u)
+                argument="$OPTARG"
+                nextchar="$(expr substr $argument 1 1)"
+                if [ -z "$argument" ] || [ "$nextchar" = "-" ]; then
+                    rc=4
+                    ERRMSG=$PGM": [WARNING] The artifact repository user is required. rc="$rc
+                    echo $ERRMSG
+                    break
+                fi
+                zBuilderPublishArtifactRepositoryUser="$argument"
+                ;;
+            s)
+                argument="$OPTARG"
+                nextchar="$(expr substr $argument 1 1)"
+                if [ -z "$argument" ] || [ "$nextchar" = "-" ]; then
+                    rc=4
+                    ERRMSG=$PGM": [WARNING] The artifact repository password file is required. rc="$rc
+                    echo $ERRMSG
+                    break
+                fi
+                zBuilderPublishArtitfRepositoryPassword="$argument"
                 ;;
             p)
                 argument="$OPTARG"
@@ -466,6 +532,12 @@ if [ $rc -eq 0 ]; then
     if [ -f "${zBuilderConfigOverrides}" ]; then
         echo $PGM": [INFO] **   Config Override :" ${zBuilderConfigOverrides}
     fi
+    if [ -f "${buildIdentifier}" ]; then
+        echo $PGM": [INFO] **          build id :" ${buildIdentifier}
+    fi  
+    if [ -f "${packageIdentifier}" ]; then
+        echo $PGM": [INFO] **         package id :" ${packageIdentifier}
+    fi
     echo $PGM": [INFO] **                HLQ:" ${HLQ}
     echo $PGM": [INFO] **             AppDir:" ${AppDir}
     echo $PGM": [INFO] **      zBuilder Path:" ${DBB_BUILD}
@@ -482,6 +554,12 @@ if [ $rc -eq 0 ]; then
         echo $PGM": [INFO] **         DBB Logger: No"
     fi
     echo $PGM": [INFO] **   Pipeline Log Dir:" ${outDir}
+    if [ ! -z "${zBuilderPublishArtifactRepositoryUser}" ]; then
+        echo $PGM": [INFO] **          ArtifactRepo User:" ${zBuilderPublishArtifactRepositoryUser}
+    fi
+    if [ ! -z "${zBuilderPublishArtitfRepositoryPassword}" ]; then
+        echo $PGM": [INFO] **      ArtifactRepo Password: xxxxx"
+    fi    
     echo $PGM": [INFO] **************************************************************"
     echo ""
 fi
@@ -507,6 +585,23 @@ if [ $rc -eq 0 ]; then
     fi
     if [ -f "${zBuilderConfigOverrides}" ]; then
         CMD="${CMD} --config ${zBuilderConfigOverrides}" # Appending Config Override file if created
+    fi
+
+    # see https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-publish#cli-authentication-options
+    if [ ! -z "${zBuilderPublishArtifactRepositoryUser}" ]; then
+        CMD="${CMD} --arid ${zBuilderPublishArtifactRepositoryUser}"
+    fi
+    if [ ! -z "${zBuilderPublishArtitfRepositoryPassword}" ]; then
+        CMD="${CMD} --arpf ${zBuilderPublishArtitfRepositoryPassword}"
+    fi
+
+    # See Build context variables via CLI
+    # https://www.ibm.com/docs/en/adffz/dbb/3.0.x?topic=index-task-package#build-context-inputs
+    if [ ! -z "${buildIdentifier}" ]; then
+        CMD="${CMD} --build-id ${buildIdentifier}"
+    fi
+    if [ ! -z "${releaseIdentifier}" ]; then
+        CMD="${CMD} --release-id ${releaseIdentifier}"
     fi
 
     echo $PGM": [INFO] ${CMD}"

--- a/Templates/Common-Backend-Scripts/zBuilder.sh
+++ b/Templates/Common-Backend-Scripts/zBuilder.sh
@@ -530,13 +530,13 @@ if [ $rc -eq 0 ]; then
     echo $PGM": [INFO] **      Pipeline Type:" ${PipelineType}
     echo $PGM": [INFO] **    Build Lifecycle:" ${Lifecycle}
     if [ -f "${zBuilderConfigOverrides}" ]; then
-        echo $PGM": [INFO] **   Config Override :" ${zBuilderConfigOverrides}
+        echo $PGM": [INFO] **    Config Override:" ${zBuilderConfigOverrides}
     fi
-    if [ -f "${buildIdentifier}" ]; then
-        echo $PGM": [INFO] **          build id :" ${buildIdentifier}
-    fi  
-    if [ -f "${packageIdentifier}" ]; then
-        echo $PGM": [INFO] **         package id :" ${packageIdentifier}
+    if [ ! -z "${buildIdentifier}" ]; then
+        echo $PGM": [INFO] **           Build Id:" ${buildIdentifier}
+    fi
+    if [ ! -z "${releaseIdentifier}" ]; then
+        echo $PGM": [INFO] **         Release Id:" ${releaseIdentifier}
     fi
     echo $PGM": [INFO] **                HLQ:" ${HLQ}
     echo $PGM": [INFO] **             AppDir:" ${AppDir}
@@ -546,7 +546,7 @@ if [ $rc -eq 0 ]; then
     echo $PGM": [INFO] **      DBB JDBC USER:" ${dbbMetadataStoreJdbcId}
     echo $PGM": [INFO] **  DBB JDBC Pwd File:" ${dbbMetadataStoreJdbcPwdFile}
     if [ ! -z "${dbbMetadataStoreJdbcUrl}" ]; then
-        echo $PGM": [INFO] **      DBB JDBC Url :" ${dbbMetadataStoreJdbcUrl}
+        echo $PGM": [INFO] **       DBB JDBC Url:" ${dbbMetadataStoreJdbcUrl}
     fi
     if [ ${LoggerConfig} -eq 1 ]; then
         echo $PGM": [INFO] **         DBB Logger:" ${DBBLogger}
@@ -555,11 +555,11 @@ if [ $rc -eq 0 ]; then
     fi
     echo $PGM": [INFO] **   Pipeline Log Dir:" ${outDir}
     if [ ! -z "${zBuilderPublishArtifactRepositoryUser}" ]; then
-        echo $PGM": [INFO] **          ArtifactRepo User:" ${zBuilderPublishArtifactRepositoryUser}
+        echo $PGM": [INFO] **  ArtifactRepo User:" ${zBuilderPublishArtifactRepositoryUser}
     fi
     if [ ! -z "${zBuilderPublishArtitfRepositoryPassword}" ]; then
-        echo $PGM": [INFO] **      ArtifactRepo Password: xxxxx"
-    fi    
+        echo $PGM": [INFO] **   ArtifactRepo Pwd:" ${zBuilderPublishArtitfRepositoryPassword}
+    fi
     echo $PGM": [INFO] **************************************************************"
     echo ""
 fi


### PR DESCRIPTION
This change extends the zBuilder.sh wrapper script to support passing artifact repository credentials to the zBuilder publish task, and adds build/release identifier pass-through for the package task. Credentials can be supplied either through pipelineBackend.config or overridden directly via new CLI flags.